### PR TITLE
fix(web): 修正 prod client 端 API base（NEXT_PUBLIC_API_URL build-time 內嵌）

### DIFF
--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -5,6 +5,11 @@ ENV NEXT_TELEMETRY_DISABLED=1
 COPY package.json package-lock.json ./
 RUN npm ci
 COPY . .
+# NEXT_PUBLIC_* 於 build 時內嵌進前端 JS，必須在 build 前設定（runtime env 無效）。
+# 預設空字串＝瀏覽器走同源相對路徑（prod 由 nginx 將 /api 轉給 cpbl-api）；
+# 需要絕對網址時以 --build-arg NEXT_PUBLIC_API_URL=... 覆蓋。
+ARG NEXT_PUBLIC_API_URL=""
+ENV NEXT_PUBLIC_API_URL=$NEXT_PUBLIC_API_URL
 # 資料頁為 force-dynamic，build 時不會預抓 API
 RUN npm run build
 


### PR DESCRIPTION
## 問題
prod 上 /predict、/players/[id]、/matchups、/splits（皆 client component）在瀏覽器抓 API 失敗。

## 根因
`NEXT_PUBLIC_API_URL` 是 Next.js **build-time** 內嵌變數，但 web/Dockerfile 未宣告對應 `ARG`，`npm run build` 時其為 undefined，client 取 fallback `http://localhost:4001`（瀏覽器抓不到 + https 頁面 mixed-content）。compose 的 `environment:` 屬 runtime，對已內嵌的 `NEXT_PUBLIC_*` 無效。

## 修正
Dockerfile 於 build 前加 `ARG NEXT_PUBLIC_API_URL=""` + `ENV`，預設空字串＝瀏覽器走同源相對路徑（已驗證 `https://cpbl.ruan-ruan.com/api/v1/...` 經 nginx 可達）。需要絕對網址時可 `--build-arg` 覆蓋。server component（API_URL 走容器內網）不受影響。

🤖 Generated with [Claude Code](https://claude.com/claude-code)