### PR TITLE
feat: 近期賽事更新爬蟲 + 刷新紀錄/缺漏檢查

### DIFF
--- a/migrations/015_refresh_log.sql
+++ b/migrations/015_refresh_log.sql
@@ -1,0 +1,16 @@
+-- 資料刷新紀錄：每次近期賽事更新寫一列，記錄時間、區間、完成場次與各表更新數，
+-- 供追蹤資料新鮮度與偵測缺漏（避免某天比賽結果沒抓到卻無感）。
+CREATE TABLE IF NOT EXISTS cpbl.refresh_log (
+    id              bigint GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+    refreshed_at    timestamptz NOT NULL DEFAULT now(),
+    scope           text NOT NULL,        -- 例：recent-games
+    from_date       date,
+    to_date         date,
+    games_total     int,                  -- 區間內賽程總場次（含未開打）
+    games_completed int,                  -- 區間內已完成場次（比分 > 0）
+    detail          jsonb,                -- 各表更新列數等明細
+    ok              boolean NOT NULL DEFAULT true,
+    note            text                  -- 警示訊息（如某日有賽程卻無結果）
+);
+
+CREATE INDEX IF NOT EXISTS idx_refresh_log_at ON cpbl.refresh_log (refreshed_at DESC);

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,7 @@ cpbl-scrape-games = "cpbl.ingest.run_scrape:main"
 cpbl-scrape-stats = "cpbl.ingest.run_scrape_stats:main"
 cpbl-scrape-fighting = "cpbl.ingest.run_scrape_fighting:main"
 cpbl-scrape-detail = "cpbl.ingest.run_scrape_detail:main"
+cpbl-refresh-recent = "cpbl.ingest.run_refresh_recent:main"
 cpbl-build-features = "cpbl.features.run_build_features:main"
 cpbl-train = "cpbl.models.train:main"
 

--- a/src/cpbl/api/main.py
+++ b/src/cpbl/api/main.py
@@ -81,6 +81,11 @@ def info() -> dict:
             "SELECT max(game_date) FROM cpbl.games WHERE home_score + away_score > 0"
         )
         metrics["last_game_date"] = last_game.isoformat() if last_game else None
+        try:  # refresh_log 可能尚未 migrate，獨立保護避免拖垮整個 info
+            last_refresh = _scalar("SELECT max(refreshed_at) FROM cpbl.refresh_log WHERE ok")
+            metrics["last_refresh"] = last_refresh.isoformat() if last_refresh else None
+        except Exception:  # noqa: BLE001
+            metrics["last_refresh"] = None
 
         if games == 0:
             status = "maintenance"  # 尚未匯入任何賽事

--- a/src/cpbl/ingest/run_refresh_recent.py
+++ b/src/cpbl/ingest/run_refresh_recent.py
@@ -1,0 +1,96 @@
+"""CLI：抓昨天/今天比賽需更新的數值，並寫入刷新紀錄、偵測缺漏。
+
+更新內容（皆當季）：
+- games：官網逐場賽程/結果（一次抓整年，自然涵蓋昨天/今天的比分與勝敗投）
+- 累計數據：投手/打者/守備/團隊（受近期比賽影響的季累計值）
+
+每次執行於 cpbl.refresh_log 記一列（時間、區間、完成場次、各表更新數）。
+若昨天有賽程卻未全部完成，於 note 警示（可能延賽或資料缺漏）。
+抓取失敗也會記一列（ok=false）並以非零結束碼退出，避免「無聲缺漏」。
+
+    uv run cpbl-refresh-recent
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import sys
+from datetime import date, timedelta
+
+from cpbl.db import conn, migrate
+from cpbl.ingest.cpbl_site import scrape_games
+from cpbl.ingest.cpbl_stats import scrape_all
+
+log = logging.getLogger("cpbl.refresh")
+
+
+def _recent_counts(year: int, days: list[date]) -> list[tuple[date, int, int]]:
+    """回傳 [(日期, 總場次, 已完成場次)]（含未開打）。"""
+    with conn() as c:
+        rows = c.execute(
+            """
+            SELECT game_date, count(*),
+                   count(*) FILTER (WHERE home_score + away_score > 0)
+            FROM cpbl.games
+            WHERE year = %s AND game_date = ANY(%s)
+            GROUP BY game_date ORDER BY game_date
+            """,
+            (year, days),
+        ).fetchall()
+    return [(d, t, comp) for d, t, comp in rows]
+
+
+def _log_refresh(scope: str, frm: date, to: date, total: int, completed: int,
+                 detail: dict, ok: bool, note: str | None) -> None:
+    with conn() as c:
+        c.execute(
+            """
+            INSERT INTO cpbl.refresh_log
+                (scope, from_date, to_date, games_total, games_completed, detail, ok, note)
+            VALUES (%s, %s, %s, %s, %s, %s::jsonb, %s, %s)
+            """,
+            (scope, frm, to, total, completed, json.dumps(detail), ok, note),
+        )
+
+
+def main() -> None:
+    logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(name)s | %(message)s")
+    today = date.today()
+    yesterday = today - timedelta(days=1)
+    year = today.year
+    migrate()
+
+    try:
+        games = scrape_games(year, year)
+        stats = scrape_all(year, year, year)
+    except Exception as e:  # noqa: BLE001 — 失敗也要留痕，避免無聲缺漏
+        log.error("抓取失敗：%s", e)
+        _log_refresh("recent-games", yesterday, today, 0, 0,
+                     {"error": str(e)}, ok=False, note=f"抓取失敗：{e}")
+        sys.exit(1)
+
+    recent = _recent_counts(year, [yesterday, today])
+    by_date = {d: (t, comp) for d, t, comp in recent}
+    y_total, y_done = by_date.get(yesterday, (0, 0))
+
+    # 昨天的比賽理應已打完；若有賽程卻未全完成 → 可能延賽或缺漏
+    note = None
+    if y_total > 0 and y_done < y_total:
+        note = f"昨日({yesterday}) {y_done}/{y_total} 完成，請確認是否延賽或資料缺漏"
+        log.warning(note)
+
+    total = sum(t for _, t, _ in recent)
+    completed = sum(comp for _, _, comp in recent)
+    detail = {
+        "games": games, "stats": stats,
+        "recent": [{"date": d.isoformat(), "total": t, "completed": comp} for d, t, comp in recent],
+    }
+    _log_refresh("recent-games", yesterday, today, total, completed, detail, ok=True, note=note)
+
+    log.info("刷新完成 | 近兩日場次 %s | games=%s stats=%s",
+             {d.isoformat(): f"{comp}/{t}" for d, t, comp in recent}, games, stats)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## 摘要
新增 `cpbl-refresh-recent`：定期更新昨天/今天比賽所需數值，並留下刷新紀錄與缺漏檢查，避免資料無聲缺失。

## 內容
- **更新**（皆當季）：games 逐場賽程/結果（整年抓，含昨天/今天比分與勝敗投）+ 投打守備團隊累計數據。
- **刷新紀錄**：`migrations/015_refresh_log.sql` 新增 `cpbl.refresh_log`，每次執行記一列（時間、區間、總/完成場次、各表更新數 jsonb）。
- **缺漏檢查**：昨天有賽程卻未全部完成 → `note` 警示（可能延賽或缺漏）；抓取失敗也記一列 `ok=false` 並以非零碼退出。
- **新鮮度可見**：`/api/info` metrics 加 `last_refresh`（獨立 try 保護，未 migrate 不影響 info 契約）。

## 驗證
本機實跑：近兩日 2026-06-16 `1/1`、2026-06-17 `0/2`（今日未打不誤報），refresh_log 正確寫入，`/api/info` 顯示 `last_refresh`。`ruff` 通過。

## 用法
```
uv run cpbl-refresh-recent           # 本機（台灣 IP）更新 + 記錄
```
建議排程每日賽後執行；推上線可接 refresh-cpbl-prod.sh（SKIP_SCRAPE）同步。

🤖 Generated with [Claude Code](https://claude.com/claude-code)