### PR TITLE
feat: 每場賽況（逐打席+逐局比分）+ 近期更新增量化

### DIFF
--- a/migrations/016_game_log.sql
+++ b/migrations/016_game_log.sql
@@ -1,0 +1,56 @@
+-- 每場賽況：逐局比分（scoreboard）+ 逐打席事件流（live log）。
+-- 來源 box/getlive 的 ScoreboardJson / LiveLogJson。冪等 UPSERT。
+
+-- 逐局比分（每隊每局）
+CREATE TABLE IF NOT EXISTS cpbl.game_scoreboard (
+    year               smallint NOT NULL,
+    kind_code          text     NOT NULL,
+    game_sno           int      NOT NULL,
+    team_no            text     NOT NULL,
+    inning_seq         int      NOT NULL,
+    visiting_home_type text,                -- 1=客隊 2=主隊
+    team_name          text,
+    score_cnt          int,                 -- 該局得分
+    hitting_cnt        int,                 -- 該局安打
+    error_cnt          int,                 -- 該局失誤
+    PRIMARY KEY (year, kind_code, game_sno, team_no, inning_seq)
+);
+
+-- 逐打席/逐事件（一筆＝一個事件，含即時局數/出局/球數/壘況/比分/中文描述）
+CREATE TABLE IF NOT EXISTS cpbl.game_livelog (
+    year                smallint NOT NULL,
+    kind_code           text     NOT NULL,
+    game_sno            int      NOT NULL,
+    main_event_no       text     NOT NULL,  -- 場內事件序（唯一）
+    inning_seq          int,
+    visiting_home_type  text,               -- 1=上半(客) 2=下半(主)
+    batting_order       int,
+    out_cnt             int,
+    ball_cnt            int,
+    strike_cnt          int,
+    pitch_cnt           int,
+    content             text,               -- 中文事件描述
+    action_name         text,
+    batting_action_name text,
+    defend_station_code text,
+    hitter_acnt         text,
+    hitter_name         text,
+    pitcher_acnt        text,
+    pitcher_name        text,
+    catcher_acnt        text,
+    catcher_name        text,
+    first_base          text,               -- 壘上跑者（acnt 或空）
+    second_base         text,
+    third_base          text,
+    is_strike           boolean,
+    is_ball             boolean,
+    is_score            boolean,
+    is_change_player    boolean,
+    is_special_event    boolean,
+    visiting_score      int,                -- 該事件後即時比分
+    home_score          int,
+    PRIMARY KEY (year, kind_code, game_sno, main_event_no)
+);
+
+CREATE INDEX IF NOT EXISTS idx_scoreboard_game ON cpbl.game_scoreboard (year, kind_code, game_sno);
+CREATE INDEX IF NOT EXISTS idx_livelog_game ON cpbl.game_livelog (year, kind_code, game_sno, inning_seq);

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,7 @@ cpbl-scrape-stats = "cpbl.ingest.run_scrape_stats:main"
 cpbl-scrape-fighting = "cpbl.ingest.run_scrape_fighting:main"
 cpbl-scrape-detail = "cpbl.ingest.run_scrape_detail:main"
 cpbl-refresh-recent = "cpbl.ingest.run_refresh_recent:main"
+cpbl-scrape-gamelog = "cpbl.ingest.run_scrape_gamelog:main"
 cpbl-build-features = "cpbl.features.run_build_features:main"
 cpbl-train = "cpbl.models.train:main"
 

--- a/src/cpbl/ingest/cpbl_gamelog.py
+++ b/src/cpbl/ingest/cpbl_gamelog.py
@@ -1,0 +1,146 @@
+"""每場賽況爬蟲：box/getlive 的 ScoreboardJson（逐局比分）+ LiveLogJson（逐打席事件）。
+
+一個 token 可重用於多場 getlive。冪等 UPSERT；偶發非 JSON 回應時重取 token。
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import re
+import time
+
+import httpx
+
+from cpbl.db import conn
+from cpbl.ingest.cpbl_site import BASE, KIND_REGULAR, UA
+
+log = logging.getLogger("cpbl.gamelog")
+
+BOX_PAGE = f"{BASE}/box"
+LIVE_ENDPOINT = f"{BASE}/box/getlive"
+_HIDDEN_RE = re.compile(r'name="__RequestVerificationToken"[^>]*value="([^"]+)"')
+
+
+def _i(v) -> int | None:
+    try:
+        return int(float(v)) if v not in (None, "") else None
+    except (TypeError, ValueError):
+        return None
+
+
+def _b(v) -> bool | None:
+    if v in (None, ""):
+        return None
+    return str(v) in ("1", "true", "True", "Y")
+
+
+def _scoreboard_rows(year: int, kind: str, sno: int, data: list[dict]) -> list[tuple]:
+    return [
+        (year, kind, sno, r.get("TeamNo"), _i(r.get("InningSeq")), r.get("VisitingHomeType"),
+         r.get("TeamName"), _i(r.get("ScoreCnt")), _i(r.get("HittingCnt")), _i(r.get("ErrorCnt")))
+        for r in data if r.get("TeamNo") and r.get("InningSeq") is not None
+    ]
+
+
+def _livelog_rows(year: int, kind: str, sno: int, data: list[dict]) -> list[tuple]:
+    out = []
+    for r in data:
+        if not r.get("MainEventNo"):
+            continue
+        out.append((
+            year, kind, sno, r.get("MainEventNo"), _i(r.get("InningSeq")), r.get("VisitingHomeType"),
+            _i(r.get("BattingOrder")), _i(r.get("OutCnt")), _i(r.get("BallCnt")), _i(r.get("StrikeCnt")),
+            _i(r.get("PitchCnt")), r.get("Content"), r.get("ActionName"), r.get("BattingActionName"),
+            r.get("DefendStationCode"), r.get("HitterAcnt"), r.get("HitterName"),
+            r.get("PitcherAcnt"), r.get("PitcherName"), r.get("CatcherAcnt"), r.get("CatcherName"),
+            r.get("FirstBase") or None, r.get("SecondBase") or None, r.get("ThirdBase") or None,
+            _b(r.get("IsStrike")), _b(r.get("IsBall")), _b(r.get("IsScoreCnt")),
+            _b(r.get("IsChangePlayer")), _b(r.get("IsSpecialEvent")),
+            _i(r.get("VisitingScore")), _i(r.get("HomeScore")),
+        ))
+    return out
+
+
+_SB_COLS = ("year,kind_code,game_sno,team_no,inning_seq,visiting_home_type,team_name,"
+            "score_cnt,hitting_cnt,error_cnt")
+_LL_COLS = ("year,kind_code,game_sno,main_event_no,inning_seq,visiting_home_type,batting_order,"
+            "out_cnt,ball_cnt,strike_cnt,pitch_cnt,content,action_name,batting_action_name,"
+            "defend_station_code,hitter_acnt,hitter_name,pitcher_acnt,pitcher_name,catcher_acnt,"
+            "catcher_name,first_base,second_base,third_base,is_strike,is_ball,is_score,"
+            "is_change_player,is_special_event,visiting_score,home_score")
+
+
+def _upsert(table: str, cols: str, n_pk: int, records: list[tuple]) -> int:
+    if not records:
+        return 0
+    col_list = [c.strip() for c in cols.split(",")]
+    ph = "(" + ",".join(["%s"] * len(col_list)) + ")"
+    updates = ", ".join(f"{c}=EXCLUDED.{c}" for c in col_list[n_pk:])
+    pk = ", ".join(col_list[:n_pk])
+    with conn() as c:
+        c.cursor().executemany(
+            f"INSERT INTO cpbl.{table} ({cols}) VALUES {ph} "
+            f"ON CONFLICT ({pk}) DO UPDATE SET {updates}",
+            records,
+        )
+    return len(records)
+
+
+def scrape_gamelogs(year: int, snos: list[int], kind_code: str = KIND_REGULAR,
+                    delay: float = 0.7) -> dict:
+    """抓指定場次的賽況並 UPSERT。回傳 {games, scoreboard, livelog}。"""
+    out = {"games": 0, "scoreboard": 0, "livelog": 0}
+    if not snos:
+        return out
+    client = httpx.Client(
+        timeout=30.0, follow_redirects=True,
+        headers={"User-Agent": UA, "X-Requested-With": "XMLHttpRequest"},
+    )
+
+    def _token() -> str:
+        html = client.get(BOX_PAGE, params={"year": year, "KindCode": kind_code, "gameSno": 1}).text
+        m = _HIDDEN_RE.search(html)
+        if not m:
+            raise RuntimeError("box 頁找不到 token（官網可能改版）")
+        return m.group(1)
+
+    try:
+        token = _token()
+        for sno in snos:
+            time.sleep(delay)
+            try:
+                resp = client.post(
+                    LIVE_ENDPOINT,
+                    data={"GameSno": str(sno), "KindCode": kind_code, "Year": str(year)},
+                    headers={"RequestVerificationToken": token},
+                )
+                if "json" not in resp.headers.get("content-type", ""):
+                    token = _token()
+                    continue
+                payload = resp.json()
+            except httpx.HTTPError as e:
+                log.warning("getlive 失敗 sno=%s: %s", sno, e)
+                continue
+            sb = json.loads(payload.get("ScoreboardJson") or "[]")
+            ll = json.loads(payload.get("LiveLogJson") or "[]")
+            out["scoreboard"] += _upsert("game_scoreboard", _SB_COLS, 5,
+                                         _scoreboard_rows(year, kind_code, sno, sb))
+            out["livelog"] += _upsert("game_livelog", _LL_COLS, 4,
+                                      _livelog_rows(year, kind_code, sno, ll))
+            out["games"] += 1
+            log.info("sno=%s scoreboard=%d livelog=%d", sno, len(sb), len(ll))
+    finally:
+        client.close()
+    return out
+
+
+def completed_snos(year: int, kind_code: str = KIND_REGULAR) -> list[int]:
+    """本季已完成（比分>0）場次的 game_sno。"""
+    with conn() as c:
+        rows = c.execute(
+            "SELECT game_sno FROM cpbl.games WHERE year = %s AND kind_code = %s "
+            "AND home_score + away_score > 0 ORDER BY game_sno",
+            (year, kind_code),
+        ).fetchall()
+    return [r[0] for r in rows]

--- a/src/cpbl/ingest/cpbl_player_detail.py
+++ b/src/cpbl/ingest/cpbl_player_detail.py
@@ -191,14 +191,22 @@ VS_TEAM_YEAR = 2026  # 對戰各隊官網僅本季 A、逐年
 
 
 def scrape(delay: float = 1.2, apart_combos: list[tuple[int, str]] | None = None,
-           groups: tuple[str, ...] = ("batters", "pitchers")) -> dict:
+           groups: tuple[str, ...] = ("batters", "pitchers"),
+           batter_ids: list[str] | None = None, pitcher_ids: list[str] | None = None) -> dict:
     """爬本季登錄打者(154)+投手(190) 的對戰各隊 + 分項。回傳各表寫入列數。
 
     `groups` 控制要跑哪些對象：("batters",) 只跑打者、("pitchers",) 只跑投手（續跑用）。
+    `batter_ids`/`pitcher_ids` 不為 None 時，只跑指定選手（增量更新用）。
     """
     apart_combos = apart_combos or APART_COMBOS
-    batters = _ids("batting_current") if "batters" in groups else []
-    pitchers = _ids("pitching_current") if "pitchers" in groups else []
+    if batter_ids is not None:
+        batters = batter_ids
+    else:
+        batters = _ids("batting_current") if "batters" in groups else []
+    if pitcher_ids is not None:
+        pitchers = pitcher_ids
+    else:
+        pitchers = _ids("pitching_current") if "pitchers" in groups else []
     out = {"bvt": 0, "pvt": 0, "bsplit": 0, "psplit": 0}
     log.info("選手細項：打者 %d / 投手 %d，delay=%.1fs，apart 組合=%s",
              len(batters), len(pitchers), delay, apart_combos)

--- a/src/cpbl/ingest/cpbl_site.py
+++ b/src/cpbl/ingest/cpbl_site.py
@@ -136,3 +136,60 @@ def scrape_games(start_year: int, end_year: int, kind_code: str = KIND_REGULAR) 
         log.info("year %s kind=%s: %d games", year, kind_code, n)
         time.sleep(1.0)  # 禮貌性間隔
     return totals
+
+
+BOX_PAGE = f"{BASE}/box"
+LIVE_ENDPOINT = f"{BASE}/box/getlive"
+
+
+def lineup_acnts(
+    year: int, snos: list[int], kind_code: str = KIND_REGULAR, delay: float = 0.7,
+) -> tuple[set[str], set[str]]:
+    """指定場次實際上場的選手 acnt：回傳 (打者集合, 投手集合)。
+
+    走 box/getlive 的 BattingJson(HitterAcnt) / PitchingJson(PitcherAcnt)；
+    用於只增量更新「當日有上場」選手的對戰/分項，省去全名單重爬。
+    """
+    batters: set[str] = set()
+    pitchers: set[str] = set()
+    if not snos:
+        return batters, pitchers
+    client = httpx.Client(
+        timeout=30.0, follow_redirects=True,
+        headers={"User-Agent": UA, "X-Requested-With": "XMLHttpRequest"},
+    )
+
+    def _token() -> str:
+        html = client.get(BOX_PAGE, params={"year": year, "KindCode": kind_code, "gameSno": 1}).text
+        # box 頁 token 在 hidden input；保險起見也試 JS 形式
+        m = re.search(r'name="__RequestVerificationToken"[^>]*value="([^"]+)"', html) or _TOKEN_RE.search(html)
+        if not m:
+            raise RuntimeError("box 頁找不到 RequestVerificationToken（官網可能改版）")
+        return m.group(1)
+
+    try:
+        token = _token()
+        for sno in snos:
+            time.sleep(delay)
+            try:
+                resp = client.post(
+                    LIVE_ENDPOINT,
+                    data={"GameSno": str(sno), "KindCode": kind_code, "Year": str(year)},
+                    headers={"RequestVerificationToken": token},
+                )
+                if "json" not in resp.headers.get("content-type", ""):
+                    token = _token()
+                    continue
+                payload = resp.json()
+            except httpx.HTTPError as e:
+                log.warning("getlive 失敗 sno=%s: %s", sno, e)
+                continue
+            for b in json.loads(payload.get("BattingJson") or "[]"):
+                if b.get("HitterAcnt"):
+                    batters.add(b["HitterAcnt"])
+            for p in json.loads(payload.get("PitchingJson") or "[]"):
+                if p.get("PitcherAcnt"):
+                    pitchers.add(p["PitcherAcnt"])
+    finally:
+        client.close()
+    return batters, pitchers

--- a/src/cpbl/ingest/run_refresh_recent.py
+++ b/src/cpbl/ingest/run_refresh_recent.py
@@ -3,12 +3,15 @@
 更新內容（皆當季）：
 - games：官網逐場賽程/結果（一次抓整年，自然涵蓋昨天/今天的比分與勝敗投）
 - 累計數據：投手/打者/守備/團隊（受近期比賽影響的季累計值）
+- 增量對戰/分項：只更新「昨天/今天有上場」選手的 matchups / vs-team / splits
+  （由 box score 抓當日上場 acnt，省去全名單重爬；off day 或無完成場次則略過）
 
 每次執行於 cpbl.refresh_log 記一列（時間、區間、完成場次、各表更新數）。
 若昨天有賽程卻未全部完成，於 note 警示（可能延賽或資料缺漏）。
 抓取失敗也會記一列（ok=false）並以非零結束碼退出，避免「無聲缺漏」。
 
-    uv run cpbl-refresh-recent
+    uv run cpbl-refresh-recent          # 含增量對戰/分項
+    uv run cpbl-refresh-recent fast     # 只更新 games+累計，跳過對戰/分項
 """
 
 from __future__ import annotations
@@ -19,10 +22,49 @@ import sys
 from datetime import date, timedelta
 
 from cpbl.db import conn, migrate
-from cpbl.ingest.cpbl_site import scrape_games
+from cpbl.ingest import cpbl_player_detail
+from cpbl.ingest.cpbl_fighting import YEAR_CAREER, scrape_matchups
+from cpbl.ingest.cpbl_gamelog import scrape_gamelogs
+from cpbl.ingest.cpbl_site import lineup_acnts, scrape_games
 from cpbl.ingest.cpbl_stats import scrape_all
 
 log = logging.getLogger("cpbl.refresh")
+
+
+def _completed_snos(year: int, days: list[date]) -> list[int]:
+    with conn() as c:
+        rows = c.execute(
+            "SELECT game_sno FROM cpbl.games WHERE year = %s AND game_date = ANY(%s) "
+            "AND home_score + away_score > 0 ORDER BY game_sno",
+            (year, days),
+        ).fetchall()
+    return [r[0] for r in rows]
+
+
+def _roster_ids(table: str) -> set[str]:
+    with conn() as c:
+        return {r[0] for r in c.execute(f"SELECT player_id FROM cpbl.{table}").fetchall()}
+
+
+def _incremental_detail(year: int, days: list[date], delay: float = 1.2) -> dict:
+    """只更新當日上場且本季登錄選手的 對戰/分項。回傳摘要。"""
+    snos = _completed_snos(year, days)
+    if not snos:
+        return {"skipped": "近兩日無已完成場次"}
+    # 賽況（逐局比分 + 逐打席事件）：當日完成場
+    gamelog = scrape_gamelogs(year, snos)
+    batters_played, pitchers_played = lineup_acnts(year, snos)
+    cur_b, cur_p = _roster_ids("batting_current"), _roster_ids("pitching_current")
+    rb = sorted(batters_played & cur_b)
+    rp = sorted(pitchers_played & cur_p)
+    if not rb and not rp:
+        return {"completed_games": len(snos), "gamelog": gamelog,
+                "lineup_batters": 0, "lineup_pitchers": 0}
+    # 對戰：重爬有上場打者的生涯對戰即涵蓋所有變動的 (打者,投手) 組合
+    m = scrape_matchups([YEAR_CAREER], delay=delay, batter_ids=rb, pitcher_ids=cur_p)
+    d = cpbl_player_detail.scrape(delay=delay, batter_ids=rb, pitcher_ids=rp)
+    return {"completed_games": len(snos), "gamelog": gamelog,
+            "lineup_batters": len(rb), "lineup_pitchers": len(rp), "matchup_rows": m, **d}
 
 
 def _recent_counts(year: int, days: list[date]) -> list[tuple[date, int, int]]:
@@ -56,6 +98,7 @@ def _log_refresh(scope: str, frm: date, to: date, total: int, completed: int,
 
 def main() -> None:
     logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(name)s | %(message)s")
+    skip_detail = len(sys.argv) > 1 and sys.argv[1] == "fast"
     today = date.today()
     yesterday = today - timedelta(days=1)
     year = today.year
@@ -64,6 +107,7 @@ def main() -> None:
     try:
         games = scrape_games(year, year)
         stats = scrape_all(year, year, year)
+        detail_inc = {} if skip_detail else _incremental_detail(year, [yesterday, today])
     except Exception as e:  # noqa: BLE001 — 失敗也要留痕，避免無聲缺漏
         log.error("抓取失敗：%s", e)
         _log_refresh("recent-games", yesterday, today, 0, 0,
@@ -83,13 +127,13 @@ def main() -> None:
     total = sum(t for _, t, _ in recent)
     completed = sum(comp for _, _, comp in recent)
     detail = {
-        "games": games, "stats": stats,
+        "games": games, "stats": stats, "incremental_detail": detail_inc,
         "recent": [{"date": d.isoformat(), "total": t, "completed": comp} for d, t, comp in recent],
     }
     _log_refresh("recent-games", yesterday, today, total, completed, detail, ok=True, note=note)
 
-    log.info("刷新完成 | 近兩日場次 %s | games=%s stats=%s",
-             {d.isoformat(): f"{comp}/{t}" for d, t, comp in recent}, games, stats)
+    log.info("刷新完成 | 近兩日場次 %s | games=%s stats=%s | 增量對戰/分項=%s",
+             {d.isoformat(): f"{comp}/{t}" for d, t, comp in recent}, games, stats, detail_inc)
 
 
 if __name__ == "__main__":

--- a/src/cpbl/ingest/run_scrape_gamelog.py
+++ b/src/cpbl/ingest/run_scrape_gamelog.py
@@ -1,0 +1,30 @@
+"""CLI：回填本季每場賽況（逐局比分 + 逐打席事件流）。
+
+    uv run cpbl-scrape-gamelog            # 本季所有已完成場次
+    uv run cpbl-scrape-gamelog 2026       # 指定年份
+
+冪等 UPSERT，可重跑。
+"""
+
+from __future__ import annotations
+
+import logging
+import sys
+from datetime import date
+
+from cpbl.db import migrate
+from cpbl.ingest.cpbl_gamelog import completed_snos, scrape_gamelogs
+
+
+def main() -> None:
+    logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(name)s | %(message)s")
+    year = int(sys.argv[1]) if len(sys.argv) >= 2 else date.today().year
+    migrate()
+    snos = completed_snos(year)
+    logging.getLogger("cpbl.gamelog").info("回填 %d 場已完成賽事的賽況 …", len(snos))
+    out = scrape_gamelogs(year, snos)
+    logging.getLogger("cpbl.gamelog").info("done: %s", out)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## 摘要
新增每場「賽況」資料層，並讓 cpbl-refresh-recent 增量更新對戰/分項/賽況，做到每日不缺漏又不重爬。

## 賽況資料層（migration 016）
- `cpbl.game_scoreboard`：逐局比分（每隊每局 得分/安打/失誤）。
- `cpbl.game_livelog`：逐打席事件（局/上下半/出局/球數/壘上跑者/即時比分/打者投手捕手/中文描述）。
- 來源 box/getlive 的 ScoreboardJson / LiveLogJson；`cpbl-scrape-gamelog` 回填。
- 已回填本季：**151 場、scoreboard 2,738、livelog 45,626 列**。

## 近期更新增量化
- `cpbl_site.lineup_acnts`：由 box score 抓當日上場 acnt。
- `cpbl_player_detail.scrape` 支援 `batter_ids/pitcher_ids` → 只更新有上場選手。
- `cpbl-refresh-recent` 增量更新：當日上場選手的對戰/分項 + 當日完成場的賽況，並記入 refresh_log。`fast` 參數可只更新 games+累計。

## 驗證
單場煙霧測試（第166場 scoreboard 18 / livelog 286，比分與 games 一致）；增量 refresh 實跑（24 打者/8 投手 → matchups 2840、vs-team 153、splits 4149 列更新）；全季回填完成。`ruff` 通過。

🤖 Generated with [Claude Code](https://claude.com/claude-code)