### PR TITLE
feat: 賽況頁（計分板+逐打席）+ 賽況納入 prod 同步

### DIFF
--- a/scripts/refresh-cpbl-prod.sh
+++ b/scripts/refresh-cpbl-prod.sh
@@ -87,6 +87,13 @@ if [ -n "${WITH_DETAIL:-}" ]; then
     item_name item_note wins loses starts complete_games shutouts save_ok inning_pitched_cnt \
     inning_pitched_div3 plate_appearances pitch_cnt strikes balls hits home_runs sac_hit sac_fly bb ibb \
     hbp so wild_pitch balk runs earned_runs
+  sync_table game_scoreboard "year,kind_code,game_sno,team_no,inning_seq" \
+    visiting_home_type team_name score_cnt hitting_cnt error_cnt
+  sync_table game_livelog "year,kind_code,game_sno,main_event_no" \
+    inning_seq visiting_home_type batting_order out_cnt ball_cnt strike_cnt pitch_cnt content \
+    action_name batting_action_name defend_station_code hitter_acnt hitter_name pitcher_acnt \
+    pitcher_name catcher_acnt catcher_name first_base second_base third_base is_strike is_ball \
+    is_score is_change_player is_special_event visiting_score home_score
 fi
 
 echo "==> 3/3 VPS 重建賽果特徵"

--- a/src/cpbl/api/main.py
+++ b/src/cpbl/api/main.py
@@ -590,3 +590,62 @@ def player_season(player_id: str, season: int = Query(DEFAULT_SEASON)) -> dict:
     if p:
         out["pitching"] = p[0]
     return out
+
+
+# ---------- 每場賽況 ----------
+
+@app.get("/api/v1/games/recent")
+def games_recent(
+    limit: int = Query(40, ge=1, le=200),
+    season: int = Query(DEFAULT_SEASON),
+) -> dict:
+    """近期已完成比賽列表（供賽況頁選擇）。"""
+    with conn() as c:
+        cur = c.cursor()
+        cur.execute(
+            """
+            SELECT year, kind_code, game_sno, game_date,
+                   away_team_name, away_team_code, away_score,
+                   home_team_name, home_team_code, home_score
+            FROM cpbl.games
+            WHERE year = %s AND home_score + away_score > 0
+            ORDER BY game_date DESC, game_sno DESC
+            LIMIT %s
+            """,
+            (season, limit),
+        )
+        return {"season": season, "items": _dicts(cur)}
+
+
+@app.get("/api/v1/games/{game_sno}/live")
+def game_live(
+    game_sno: int,
+    season: int = Query(DEFAULT_SEASON),
+    kind_code: str = Query("A", pattern="^(A|C|E)$"),
+) -> dict:
+    """單場賽況：賽事資訊 + 逐局比分 + 逐打席事件流。"""
+    with conn() as c:
+        cur = c.cursor()
+        cur.execute(
+            """
+            SELECT year, kind_code, game_sno, game_date, venue,
+                   away_team_name, away_team_code, away_score,
+                   home_team_name, home_team_code, home_score
+            FROM cpbl.games WHERE year = %s AND kind_code = %s AND game_sno = %s
+            """,
+            (season, kind_code, game_sno),
+        )
+        g = _dicts(cur)
+        cur.execute(
+            "SELECT * FROM cpbl.game_scoreboard WHERE year=%s AND kind_code=%s AND game_sno=%s "
+            "ORDER BY visiting_home_type, inning_seq",
+            (season, kind_code, game_sno),
+        )
+        scoreboard = _dicts(cur)
+        cur.execute(
+            "SELECT * FROM cpbl.game_livelog WHERE year=%s AND kind_code=%s AND game_sno=%s "
+            "ORDER BY main_event_no",
+            (season, kind_code, game_sno),
+        )
+        livelog = _dicts(cur)
+    return {"game": g[0] if g else None, "scoreboard": scoreboard, "livelog": livelog}

--- a/web/src/app/games/[sno]/page.tsx
+++ b/web/src/app/games/[sno]/page.tsx
@@ -1,0 +1,155 @@
+"use client";
+
+import Link from "next/link";
+import { useParams, useSearchParams } from "next/navigation";
+import { useEffect, useState } from "react";
+import { detail, type StatRow } from "@/lib/client";
+
+const n = (v: number | string | null) => (v === null || v === undefined ? "" : Number(v));
+
+type Live = { game: StatRow | null; scoreboard: StatRow[]; livelog: StatRow[] };
+
+function Scoreboard({ sb, game }: { sb: StatRow[]; game: StatRow }) {
+  const away = sb.filter((r) => String(r.visiting_home_type) === "1");
+  const home = sb.filter((r) => String(r.visiting_home_type) === "2");
+  const innings = [...new Set(sb.map((r) => Number(r.inning_seq)))].sort((a, b) => a - b);
+  const cell = (rows: StatRow[], inn: number) =>
+    rows.find((r) => Number(r.inning_seq) === inn)?.score_cnt ?? "";
+  const tot = (rows: StatRow[], key: string) =>
+    rows.reduce((s, r) => s + (Number(r[key]) || 0), 0);
+
+  const row = (label: string, rows: StatRow[], score: number) => (
+    <tr className="border-t border-white/5">
+      <td className="whitespace-nowrap px-3 py-2 font-sans font-medium">{label}</td>
+      {innings.map((inn) => (
+        <td key={inn} className="px-2.5 py-2 text-center text-white/70">{String(cell(rows, inn))}</td>
+      ))}
+      <td className="px-2.5 py-2 text-center font-semibold text-emerald-400">{score}</td>
+      <td className="px-2.5 py-2 text-center text-white/50">{tot(rows, "hitting_cnt")}</td>
+      <td className="px-2.5 py-2 text-center text-white/50">{tot(rows, "error_cnt")}</td>
+    </tr>
+  );
+
+  return (
+    <div className="overflow-x-auto rounded-xl border border-white/10">
+      <table className="w-full text-sm font-mono tabular-nums">
+        <thead className="bg-white/5 text-white/50">
+          <tr>
+            <th className="px-3 py-2 text-left font-medium">隊伍</th>
+            {innings.map((inn) => <th key={inn} className="px-2.5 py-2 font-medium">{inn}</th>)}
+            <th className="px-2.5 py-2 font-medium">R</th>
+            <th className="px-2.5 py-2 font-medium">H</th>
+            <th className="px-2.5 py-2 font-medium">E</th>
+          </tr>
+        </thead>
+        <tbody>
+          {row(String(game.away_team_name), away, Number(game.away_score))}
+          {row(String(game.home_team_name), home, Number(game.home_score))}
+        </tbody>
+      </table>
+    </div>
+  );
+}
+
+function PlayByPlay({ log }: { log: StatRow[] }) {
+  // 依「局 × 上下半」分組
+  const groups: { inning: number; half: string; events: StatRow[] }[] = [];
+  for (const e of log) {
+    const last = groups[groups.length - 1];
+    if (!last || last.inning !== Number(e.inning_seq) || last.half !== String(e.visiting_home_type)) {
+      groups.push({ inning: Number(e.inning_seq), half: String(e.visiting_home_type), events: [e] });
+    } else {
+      last.events.push(e);
+    }
+  }
+
+  return (
+    <div className="space-y-5">
+      {groups.map((g, gi) => (
+        <div key={gi} className="rounded-xl border border-white/10 bg-white/[0.02] p-4">
+          <h3 className="mb-2 text-sm font-semibold text-emerald-400">
+            {g.inning} 局{g.half === "1" ? "上" : "下"}
+          </h3>
+          <div className="space-y-0.5">
+            {g.events.map((e, i) => {
+              const prev = g.events[i - 1];
+              const newBatter = !prev || prev.hitter_acnt !== e.hitter_acnt;
+              const isScore = Boolean(e.is_score);
+              const content = String(e.content ?? "");
+              const isPitch = content.length <= 8; // 粗略：短句多為單球描述
+              return (
+                <div key={i}>
+                  {newBatter && e.hitter_name && (
+                    <div className="mt-2.5 text-sm font-medium text-white/80">
+                      🏏 {String(e.hitter_name)}
+                      <span className="ml-2 text-xs text-white/40">投：{String(e.pitcher_name ?? "")}</span>
+                    </div>
+                  )}
+                  <div
+                    className={`pl-5 ${
+                      isScore ? "text-emerald-400" : isPitch ? "text-xs text-white/40" : "text-sm text-white/80"
+                    }`}
+                  >
+                    {content}
+                    {isScore && (
+                      <span className="ml-2 font-mono text-xs">
+                        ({n(e.visiting_score)}-{n(e.home_score)})
+                      </span>
+                    )}
+                  </div>
+                </div>
+              );
+            })}
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+export default function GameLivePage() {
+  const { sno } = useParams<{ sno: string }>();
+  const sp = useSearchParams();
+  const kind = sp.get("kind") || "A";
+  const [data, setData] = useState<Live | null>(null);
+  const [err, setErr] = useState(false);
+
+  useEffect(() => {
+    detail.gameLive(Number(sno), kind).then((d) => setData(d as Live)).catch(() => setErr(true));
+  }, [sno, kind]);
+
+  if (err) return <p className="text-sm text-white/50">載入賽況失敗。</p>;
+  if (!data) return <p className="text-sm text-white/40">載入中…</p>;
+  if (!data.game) return <p className="text-sm text-white/50">查無此場比賽。</p>;
+
+  const g = data.game;
+  return (
+    <div>
+      <Link href="/games" className="text-xs text-white/40 hover:text-emerald-400">← 返回賽況列表</Link>
+      <header className="mb-5 mt-2">
+        <h1 className="text-2xl font-bold">
+          {String(g.away_team_name)} <span className="font-mono">{n(g.away_score)}</span>
+          <span className="mx-2 text-white/30">@</span>
+          {String(g.home_team_name)} <span className="font-mono">{n(g.home_score)}</span>
+        </h1>
+        <p className="mt-1 text-sm text-white/50">
+          {String(g.game_date ?? "")}　{String(g.venue ?? "")}
+        </p>
+      </header>
+
+      <section className="mb-8">
+        <h2 className="mb-2 text-lg font-semibold">逐局比分</h2>
+        <Scoreboard sb={data.scoreboard} game={g} />
+      </section>
+
+      <section>
+        <h2 className="mb-3 text-lg font-semibold">逐打席賽況</h2>
+        {data.livelog.length === 0 ? (
+          <p className="text-sm text-white/40">無逐打席資料。</p>
+        ) : (
+          <PlayByPlay log={data.livelog} />
+        )}
+      </section>
+    </div>
+  );
+}

--- a/web/src/app/games/page.tsx
+++ b/web/src/app/games/page.tsx
@@ -1,0 +1,62 @@
+import Link from "next/link";
+import { api } from "@/lib/api";
+
+export const dynamic = "force-dynamic";
+
+export default async function GamesPage() {
+  const { season, items } = await api.gamesRecent();
+
+  // 依日期分組
+  const byDate = new Map<string, typeof items>();
+  for (const g of items) {
+    const arr = byDate.get(g.game_date) ?? [];
+    arr.push(g);
+    byDate.set(g.game_date, arr);
+  }
+
+  return (
+    <div>
+      <header className="mb-5">
+        <h1 className="text-2xl font-bold">{season} 球季 · 賽況</h1>
+        <p className="mt-2 text-sm text-white/50">點任一場看逐局比分與逐打席賽況（play-by-play）。</p>
+      </header>
+
+      <div className="space-y-6">
+        {[...byDate.entries()].map(([d, games]) => (
+          <section key={d}>
+            <h2 className="mb-2 text-sm font-medium text-white/50">{d}</h2>
+            <div className="grid gap-2 sm:grid-cols-2">
+              {games.map((g) => {
+                const awayWin = g.away_score > g.home_score;
+                return (
+                  <Link
+                    key={g.game_sno}
+                    href={`/games/${g.game_sno}?kind=${g.kind_code}`}
+                    className="flex items-center justify-between rounded-xl border border-white/10 bg-white/[0.02] px-4 py-3 hover:bg-white/5"
+                  >
+                    <div className="space-y-1">
+                      <div className={awayWin ? "font-semibold" : "text-white/70"}>
+                        {g.away_team_name}
+                      </div>
+                      <div className={!awayWin ? "font-semibold" : "text-white/70"}>
+                        {g.home_team_name}
+                      </div>
+                    </div>
+                    <div className="space-y-1 text-right font-mono tabular-nums">
+                      <div className={awayWin ? "font-semibold text-emerald-400" : "text-white/70"}>
+                        {g.away_score}
+                      </div>
+                      <div className={!awayWin ? "font-semibold text-emerald-400" : "text-white/70"}>
+                        {g.home_score}
+                      </div>
+                    </div>
+                  </Link>
+                );
+              })}
+            </div>
+          </section>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/web/src/app/layout.tsx
+++ b/web/src/app/layout.tsx
@@ -18,6 +18,7 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
             </Link>
             <nav className="flex gap-4 text-sm text-white/50">
               <Link href="/" className="hover:text-emerald-400">本季戰績</Link>
+              <Link href="/games" className="hover:text-emerald-400">賽況</Link>
               <Link href="/batters" className="hover:text-emerald-400">打者</Link>
               <Link href="/pitchers" className="hover:text-emerald-400">投手</Link>
               <Link href="/fielding" className="hover:text-emerald-400">守備</Link>

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -105,7 +105,22 @@ export type FieldingResponse = {
   items: FieldingRecord[];
 };
 
+export type GameSummary = {
+  year: number;
+  kind_code: string;
+  game_sno: number;
+  game_date: string;
+  away_team_name: string;
+  away_team_code: string;
+  away_score: number;
+  home_team_name: string;
+  home_team_code: string;
+  home_score: number;
+};
+export type GamesRecentResponse = { season: number; items: GameSummary[] };
+
 export const api = {
+  gamesRecent: (limit = 60) => get<GamesRecentResponse>(`/api/v1/games/recent?limit=${limit}`, 120),
   standings: (season?: number) =>
     get<StandingsResponse>(`/api/v1/season/standings${season ? `?season=${season}` : ""}`),
   // 排行榜改由前端點欄位排序/隊伍篩選，故抓全名單（低門檻、大 limit）。

--- a/web/src/lib/client.ts
+++ b/web/src/lib/client.ts
@@ -128,6 +128,10 @@ export const detail = {
     clientGet<PlayerMatchupsData>(`/api/v1/players/${id}/matchups?role=${role}&kind_code=${kind}`),
   season: (id: string) =>
     clientGet<{ batting: StatRow | null; pitching: StatRow | null }>(`/api/v1/players/${id}/season`),
+  gameLive: (sno: number, kind = "A") =>
+    clientGet<{ game: StatRow | null; scoreboard: StatRow[]; livelog: StatRow[] }>(
+      `/api/v1/games/${sno}/live?kind_code=${kind}`,
+    ),
   // 全聯盟本季母體（算百分位 PR 用）
   leaders: (role: "batting" | "pitching") =>
     clientGet<{ items: StatRow[] }>(


### PR DESCRIPTION
## 內容
- **API**：`/api/v1/games/recent`（近期完成比賽）、`/api/v1/games/{sno}/live`（單場賽事資訊 + scoreboard + livelog）。
- **前端**：`/games` 近期比賽列表 → `/games/[sno]` 單場賽況（逐局計分板 R/H/E + 逐打席 play-by-play，依局/上下半分組、標示得分與即時比分）。導覽加「賽況」。
- **infra**：refresh 腳本 WITH_DETAIL 同步區塊加入 game_scoreboard / game_livelog。

## 驗證
API recent/live 實測正確（第166場 18/285）；/games、/games/166 皆 200；tsc + ruff 通過。

🤖 Generated with [Claude Code](https://claude.com/claude-code)