### PR TITLE
feat: 官方進階數據（stats.cpbl Statcast + PR）

### DIFF
--- a/migrations/017_advanced_stats.sql
+++ b/migrations/017_advanced_stats.sql
@@ -1,0 +1,25 @@
+-- 官方進階數據（stats.cpbl.com.tw，TrackMan/Statcast 風格）彙總 + 官方 PR 百分位。
+-- 打者=進攻數值；投手=被打數值（PR 已依角色定向，皆「越高越好」）。
+-- 來源為 Next.js RSC 內嵌資料，解析較脆弱；欄位對齊官方鍵（barrel% PR 官方鍵為 prlpPr）。
+CREATE TABLE IF NOT EXISTS cpbl.advanced_stats (
+    year         smallint NOT NULL,
+    acnt         text     NOT NULL,
+    role         text     NOT NULL,   -- batting / pitching
+    pa           int,
+    woba         real, woba_pr        int,
+    ba           real, ba_pr          int,
+    slg          real, slg_pr         int,
+    iso          real, iso_pr         int,
+    obp          real, obp_pr         int,
+    brl          int,  brl_pr         int,   -- 出色擊球數 Barrels
+    brlp         real, brlp_pr        int,   -- 出色擊球率 Barrel%
+    ev           real, ev_pr          int,   -- 平均擊球初速 (km/h)
+    max_ev       real, max_ev_pr      int,   -- 最高擊球初速
+    hardhitp     real, hardhitp_pr    int,   -- 強擊球率
+    kp           real, kp_pr          int,   -- 三振率
+    bbp          real, bbp_pr         int,   -- 保送率
+    whiffp       real, whiffp_pr      int,   -- 揮空率
+    chasep       real, chasep_pr      int,   -- 追打率
+    updated_at   timestamptz NOT NULL DEFAULT now(),
+    PRIMARY KEY (year, acnt, role)
+);

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,7 @@ cpbl-scrape-fighting = "cpbl.ingest.run_scrape_fighting:main"
 cpbl-scrape-detail = "cpbl.ingest.run_scrape_detail:main"
 cpbl-refresh-recent = "cpbl.ingest.run_refresh_recent:main"
 cpbl-scrape-gamelog = "cpbl.ingest.run_scrape_gamelog:main"
+cpbl-scrape-advanced = "cpbl.ingest.run_scrape_advanced:main"
 cpbl-build-features = "cpbl.features.run_build_features:main"
 cpbl-train = "cpbl.models.train:main"
 

--- a/src/cpbl/ingest/cpbl_advanced.py
+++ b/src/cpbl/ingest/cpbl_advanced.py
@@ -1,0 +1,127 @@
+"""官方進階數據爬蟲（stats.cpbl.com.tw）。
+
+該站為 Next.js App Router，資料內嵌於 RSC 串流（self.__next_f.push）。流程：
+1. GET /players/{acnt} → 取出所有 push 字串串接、unicode unescape 還原 payload。
+2. 以括號配對擷取含 "wobaPr" 的彙總物件（打者=進攻、投手=被打；PR 官方已定向）。
+冪等 UPSERT。無公開 JSON API，解析較脆弱：站改版時 _summary_object 會抓不到，據此判斷。
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import re
+import time
+
+import httpx
+
+from cpbl.db import conn
+
+log = logging.getLogger("cpbl.advanced")
+
+BASE = "https://stats.cpbl.com.tw"
+UA = "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36"
+_PUSH_RE = re.compile(r'self\.__next_f\.push\(\[1,"((?:[^"\\]|\\.)*)"\]\)')
+
+
+def _payload(client: httpx.Client, acnt: str) -> str:
+    html = client.get(f"{BASE}/players/{acnt}").text
+    chunks = _PUSH_RE.findall(html)
+    return "".join(chunks).encode().decode("unicode_escape", errors="replace")
+
+
+def _summary_object(payload: str, key: str = "wobaPr") -> dict | None:
+    """以括號配對擷取「含 key 的最內層物件」並解析。找不到/解析失敗回 None。"""
+    i = payload.find(f'"{key}"')
+    if i < 0:
+        return None
+    depth, j = 0, i
+    while j > 0:  # 往左找物件開頭
+        c = payload[j]
+        if c == "}":
+            depth += 1
+        elif c == "{":
+            if depth == 0:
+                break
+            depth -= 1
+        j -= 1
+    depth, k = 0, j
+    while k < len(payload):  # 往右括號配對找結尾
+        c = payload[k]
+        if c == "{":
+            depth += 1
+        elif c == "}":
+            depth -= 1
+            if depth == 0:
+                break
+        k += 1
+    try:
+        return json.loads(payload[j:k + 1])
+    except (json.JSONDecodeError, ValueError):
+        return None
+
+
+def _record(d: dict, year: int, acnt: str, role: str) -> tuple:
+    g = d.get
+    return (
+        year, acnt, role, g("pa"),
+        g("woba"), g("wobaPr"), g("ba"), g("baPr"), g("slg"), g("slgPr"),
+        g("iso"), g("isoPr"), g("obp"), g("obpPr"),
+        g("brl"), g("brlPr"), g("brlp"), g("prlpPr"),  # 官方 barrel% PR 鍵為 prlpPr
+        g("ev"), g("evPr"), g("maxEv"), g("maxEvPr"),
+        g("hardHitp"), g("hardHitpPr"), g("kp"), g("kpPr"), g("bbp"), g("bbpPr"),
+        g("whiffp"), g("whiffpPr"), g("chasep"), g("chasepPr"),
+    )
+
+
+_COLS = ("year,acnt,role,pa,woba,woba_pr,ba,ba_pr,slg,slg_pr,iso,iso_pr,obp,obp_pr,"
+         "brl,brl_pr,brlp,brlp_pr,ev,ev_pr,max_ev,max_ev_pr,hardhitp,hardhitp_pr,"
+         "kp,kp_pr,bbp,bbp_pr,whiffp,whiffp_pr,chasep,chasep_pr")
+
+
+def _upsert(records: list[tuple]) -> int:
+    if not records:
+        return 0
+    col_list = [c.strip() for c in _COLS.split(",")]
+    ph = "(" + ",".join(["%s"] * len(col_list)) + ")"
+    updates = ", ".join(f"{c}=EXCLUDED.{c}" for c in col_list[3:]) + ", updated_at=now()"
+    with conn() as c:
+        c.cursor().executemany(
+            f"INSERT INTO cpbl.advanced_stats ({_COLS}) VALUES {ph} "
+            f"ON CONFLICT (year, acnt, role) DO UPDATE SET {updates}",
+            records,
+        )
+    return len(records)
+
+
+def scrape_advanced(year: int, players: list[tuple[str, str]], delay: float = 1.0) -> int:
+    """players = [(acnt, role)]；抓官方進階彙總並 UPSERT。回傳成功筆數。"""
+    client = httpx.Client(timeout=40.0, headers={"User-Agent": UA}, follow_redirects=True)
+    records: list[tuple] = []
+    try:
+        for idx, (acnt, role) in enumerate(players, 1):
+            time.sleep(delay)
+            try:
+                obj = _summary_object(_payload(client, acnt))
+            except httpx.HTTPError as e:
+                log.warning("[%d/%d] acnt=%s HTTP 失敗：%s", idx, len(players), acnt, e)
+                continue
+            if not obj:
+                log.warning("[%d/%d] acnt=%s 無進階資料（或站改版）", idx, len(players), acnt)
+                continue
+            records.append(_record(obj, year, acnt, role))
+            if idx % 20 == 0:
+                log.info("[%d/%d] 進階數據抓取中…", idx, len(players))
+    finally:
+        client.close()
+    return _upsert(records)
+
+
+def current_players() -> list[tuple[str, str]]:
+    """本季登錄選手 [(acnt, role)]；同時是打者與投手者取打者（進攻數值較常看）。"""
+    with conn() as c:
+        bats = {r[0] for r in c.execute("SELECT DISTINCT player_id FROM cpbl.batting_current").fetchall()}
+        pits = {r[0] for r in c.execute("SELECT DISTINCT player_id FROM cpbl.pitching_current").fetchall()}
+    players = [(a, "batting") for a in sorted(bats)]
+    players += [(a, "pitching") for a in sorted(pits - bats)]
+    return players

--- a/src/cpbl/ingest/run_scrape_advanced.py
+++ b/src/cpbl/ingest/run_scrape_advanced.py
@@ -1,0 +1,31 @@
+"""CLI：回填本季登錄選手的官方進階數據（stats.cpbl.com.tw 彙總 + 官方 PR）。
+
+    uv run cpbl-scrape-advanced            # 本季全名單
+    uv run cpbl-scrape-advanced 1.5        # 指定每請求間隔秒數
+
+冪等 UPSERT。RSC 解析較脆弱，個別失敗會略過不中斷。
+"""
+
+from __future__ import annotations
+
+import logging
+import sys
+from datetime import date
+
+from cpbl.db import migrate
+from cpbl.ingest.cpbl_advanced import current_players, scrape_advanced
+
+
+def main() -> None:
+    logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(name)s | %(message)s")
+    delay = float(sys.argv[1]) if len(sys.argv) >= 2 else 1.0
+    year = date.today().year
+    migrate()
+    players = current_players()
+    logging.getLogger("cpbl.advanced").info("回填 %d 位選手官方進階數據 …", len(players))
+    n = scrape_advanced(year, players, delay=delay)
+    logging.getLogger("cpbl.advanced").info("done: %d 筆", n)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## 摘要
新增官方進階數據層（stats.cpbl.com.tw，TrackMan/Statcast 風格）：每位選手彙總指標 + 官方 PR 百分位。

## 內容
- `migrations/017_advanced_stats.sql`：`cpbl.advanced_stats`（role=batting/pitching）。
- 指標：擊球初速 ev/maxEv、出色擊球 brl/brlp、強擊球% hardHit、追打% chase、揮空% whiff、K%/BB%、wOBA/BA/SLG/ISO/OBP，皆含官方 PR。
- 解析：站為 Next.js RSC，資料內嵌 self.__next_f；以括號配對擷取含 wobaPr 的彙總物件（打者=進攻、投手=被打，官方已定向 PR）。
- `cpbl-scrape-advanced` 回填本季 **340 位（154 打者 + 186 投手，0 缺漏）**。

## 紅線
無公開 JSON API，解析 RSC 串流較脆弱（站改版時 _summary_object 抓不到 → 該員略過）。為 Phase 2+ 的逐球 TrackMan（option 2）預留後續。

🤖 Generated with [Claude Code](https://claude.com/claude-code)