### PR TITLE
feat: 打者好球帶紀律面板（逐球計算 + 進壘點散布）

### DIFF
--- a/scripts/refresh-cpbl-prod.sh
+++ b/scripts/refresh-cpbl-prod.sh
@@ -97,6 +97,11 @@ if [ -n "${WITH_DETAIL:-}" ]; then
   sync_table advanced_stats "year,acnt,role" \
     pa woba woba_pr ba ba_pr slg slg_pr iso iso_pr obp obp_pr brl brl_pr brlp brlp_pr ev ev_pr \
     max_ev max_ev_pr hardhitp hardhitp_pr kp kp_pr bbp bbp_pr whiffp whiffp_pr chasep chasep_pr
+  sync_table pitch_tracking "year,kind_code,game_sno,pitcher_acnt,pitch_cnt" \
+    pitcher_name hitter_acnt hitter_name inning_seq ball_cnt strike_cnt out_cnt batting_order content \
+    pitch_call auto_pitch_type tagged_pitch_type rel_speed spin_rate rel_side rel_height extension \
+    zone_speed plate_loc_side plate_loc_height hit_exit_speed hit_launch_angle hit_direction \
+    hit_distance hit_hang_time
 fi
 
 echo "==> 3/3 VPS 重建賽果特徵"

--- a/src/cpbl/api/main.py
+++ b/src/cpbl/api/main.py
@@ -663,3 +663,64 @@ def player_advanced(player_id: str, season: int = Query(DEFAULT_SEASON)) -> dict
         for row in _dicts(cur):
             out[row["role"]] = row
     return out
+
+
+# 好球帶（公尺座標近似）：左右 ±0.25、上下 0.45~1.05
+_SWING = "('InPlay','FoulBallNotFieldable','FoulBallFieldable','StrikeSwinging')"
+_CONTACT = "('InPlay','FoulBallNotFieldable','FoulBallFieldable')"
+
+
+@app.get("/api/v1/players/{player_id}/discipline")
+def player_discipline(
+    player_id: str,
+    role: str = Query("batting", pattern="^(batting|pitching)$"),
+    season: int = Query(DEFAULT_SEASON),
+) -> dict:
+    """好球帶紀律（自 pitch_tracking 計算）。batting=該打者面對；pitching=該投手誘導。
+    含揮棒/揮空/接觸/CSW/追打/帶內揮棒/好球帶比例，及進壘點散布。"""
+    col = "hitter_acnt" if role == "batting" else "pitcher_acnt"
+    pct = lambda a, b: round(a / b * 100, 1) if b else None  # noqa: E731
+    with conn() as c:
+        cur = c.cursor()
+        cur.execute(
+            f"""
+            SELECT
+              count(*) loc,
+              count(*) tot,
+              count(*) FILTER (WHERE pitch_call IN {_SWING}) sw,
+              count(*) FILTER (WHERE pitch_call = 'StrikeSwinging') wh,
+              count(*) FILTER (WHERE pitch_call IN {_CONTACT}) ct,
+              count(*) FILTER (WHERE pitch_call IN ('StrikeCalled','StrikeSwinging')) csw,
+              count(*) FILTER (WHERE iz) zone,
+              count(*) FILTER (WHERE iz AND sw0) zsw,
+              count(*) FILTER (WHERE (NOT iz) AND sw0) osw,
+              count(*) FILTER (WHERE NOT iz) ozone
+            FROM (
+              SELECT pitch_call,
+                     (abs(plate_loc_side) <= 0.25 AND plate_loc_height BETWEEN 0.45 AND 1.05) iz,
+                     (pitch_call IN {_SWING}) sw0
+              FROM cpbl.pitch_tracking
+              WHERE {col} = %s AND year = %s AND plate_loc_side IS NOT NULL
+            ) q
+            """,
+            (player_id, season),
+        )
+        loc, tot, sw, wh, ct, csw, zone, zsw, osw, ozone = cur.fetchone()
+        summary = {
+            "pitches": tot, "located": loc,
+            "swing_pct": pct(sw, loc), "whiff_pct": pct(wh, sw), "contact_pct": pct(ct, sw),
+            "csw_pct": pct(csw, loc), "zone_pct": pct(zone, loc),
+            "z_swing_pct": pct(zsw, zone), "chase_pct": pct(osw, ozone),
+        }
+        cur.execute(
+            f"""
+            SELECT plate_loc_side, plate_loc_height,
+                   (pitch_call IN {_SWING}) sw, (pitch_call = 'StrikeSwinging') wh
+            FROM cpbl.pitch_tracking
+            WHERE {col} = %s AND year = %s AND plate_loc_side IS NOT NULL
+            """,
+            (player_id, season),
+        )
+        points = [{"x": float(s), "y": float(h), "sw": sw, "wh": wh}
+                  for s, h, sw, wh in cur.fetchall()]
+    return {"player_id": player_id, "role": role, "summary": summary, "points": points}

--- a/web/src/app/players/[id]/page.tsx
+++ b/web/src/app/players/[id]/page.tsx
@@ -7,10 +7,14 @@ import {
   CartesianGrid,
   Line,
   LineChart,
+  ReferenceArea,
   ResponsiveContainer,
+  Scatter,
+  ScatterChart,
   Tooltip,
   XAxis,
   YAxis,
+  ZAxis,
 } from "recharts";
 import { detail, type PlayerProfile, type StatRow } from "@/lib/client";
 
@@ -136,6 +140,7 @@ export default function PlayerPage() {
   const [splits, setSplits] = useState<StatRow[] | null>(null);
   const [monthMetric, setMonthMetric] = useState("ops");
   const [advanced, setAdvanced] = useState<{ batting: StatRow | null; pitching: StatRow | null } | null>(null);
+  const [disc, setDisc] = useState<{ summary: Record<string, number | null>; points: { x: number; y: number; sw: boolean; wh: boolean }[] } | null>(null);
   const [tip, setTip] = useState<{ text: string; x: number; y: number } | null>(null);
 
   useEffect(() => {
@@ -158,10 +163,12 @@ export default function PlayerPage() {
     detail.splits(id, role, year, k).then((d) => setSplits(d.items)).catch(() => setSplits([]));
   }, [id, role, scope, kinds, profile]);
 
-  // 切換打/投時重設逐月指標
+  // 切換打/投時重設逐月指標、抓好球帶紀律
   useEffect(() => {
     setMonthMetric(role === "batting" ? "ops" : "era");
-  }, [role]);
+    setDisc(null);
+    detail.discipline(id, role).then(setDisc).catch(() => setDisc(null));
+  }, [id, role]);
 
   const byName = useMemo(() => {
     const m: Record<string, StatRow> = {};
@@ -363,6 +370,47 @@ export default function PlayerPage() {
           {tip.text}
         </div>
       )}
+
+      {/* 好球帶紀律 */}
+      <section className="mb-8">
+        <h2 className="mb-1 text-lg font-semibold">好球帶紀律 · {role === "batting" ? "打者" : "投手誘導"}</h2>
+        <p className="mb-3 text-[11px] text-white/30">
+          依逐球進壘點計算（僅含有 TrackMan 的場次）；好球帶為近似框，追打/好球帶% 僅供參考，
+          權威 chase%/whiff% 見上方官方數據。
+        </p>
+        {!disc ? (
+          <p className="text-sm text-white/40">載入中…</p>
+        ) : disc.points.length === 0 ? (
+          <p className="text-sm text-white/40">無逐球資料。</p>
+        ) : (
+          <div className="grid gap-6 lg:grid-cols-2">
+            <div className="grid grid-cols-3 gap-2 self-start">
+              {([["揮棒%", "swing_pct"], ["接觸%", "contact_pct"], ["揮空%", "whiff_pct"],
+                 ["CSW%", "csw_pct"], ["好球帶%", "zone_pct"], ["追打%", "chase_pct"]] as const).map(([l, k]) => (
+                <Card key={l} label={l} value={disc.summary[k] == null ? "—" : `${disc.summary[k]}%`} />
+              ))}
+            </div>
+            <div className="rounded-xl border border-white/10 bg-white/[0.02] p-4">
+              <h3 className="mb-2 text-sm font-medium text-white/70">進壘點散布（{disc.points.length} 球）</h3>
+              <ResponsiveContainer width="100%" height={300}>
+                <ScatterChart margin={{ top: 5, right: 10, left: -10, bottom: 0 }}>
+                  <CartesianGrid stroke="rgba(255,255,255,0.06)" />
+                  <XAxis type="number" dataKey="x" domain={[-0.8, 0.8]} {...axis} tickFormatter={() => ""} />
+                  <YAxis type="number" dataKey="y" domain={[-0.2, 1.6]} {...axis} tickFormatter={() => ""} />
+                  <ZAxis range={[18, 18]} />
+                  <ReferenceArea x1={-0.25} x2={0.25} y1={0.45} y2={1.05}
+                    stroke="rgba(255,255,255,0.45)" fill="rgba(255,255,255,0.04)" />
+                  <Tooltip {...tooltipStyle} cursor={{ strokeDasharray: "3 3" }} />
+                  <Scatter name="未揮棒" data={disc.points.filter((p) => !p.sw)} fill="rgba(255,255,255,0.25)" />
+                  <Scatter name="揮棒" data={disc.points.filter((p) => p.sw && !p.wh)} fill="#34d399" />
+                  <Scatter name="揮空" data={disc.points.filter((p) => p.wh)} fill="#f87171" />
+                </ScatterChart>
+              </ResponsiveContainer>
+              <p className="mt-1 text-[11px] text-white/30">綠＝揮棒（擊中/界外）、紅＝揮空、灰＝未揮棒；白框＝好球帶(近似)。</p>
+            </div>
+          </div>
+        )}
+      </section>
 
       {/* 分項明細表 */}
       <section>

--- a/web/src/lib/client.ts
+++ b/web/src/lib/client.ts
@@ -130,6 +130,10 @@ export const detail = {
     clientGet<{ batting: StatRow | null; pitching: StatRow | null }>(`/api/v1/players/${id}/season`),
   advanced: (id: string) =>
     clientGet<{ batting: StatRow | null; pitching: StatRow | null }>(`/api/v1/players/${id}/advanced`),
+  discipline: (id: string, role: "batting" | "pitching") =>
+    clientGet<{ summary: Record<string, number | null>; points: { x: number; y: number; sw: boolean; wh: boolean }[] }>(
+      `/api/v1/players/${id}/discipline?role=${role}`,
+    ),
   gameLive: (sno: number, kind = "A") =>
     clientGet<{ game: StatRow | null; scoreboard: StatRow[]; livelog: StatRow[] }>(
       `/api/v1/games/${sno}/live?kind_code=${kind}`,


### PR DESCRIPTION
## 內容
- `/api/v1/players/{id}/discipline`：由 pitch_tracking 計算 Swing%/Whiff%/Contact%/CSW%（不依賴劃帶，準確）+ Zone%/Z-Swing%/Chase%（公尺近似好球帶）+ 進壘點座標。
- 個人頁「好球帶紀律」區：指標卡 + 進壘點散布圖（揮棒綠/揮空紅/未揮棒灰 + 近似好球帶框）。role 支援打者（面對）與投手（誘導）。
- prod 同步腳本加入 `pitch_tracking`。

## 誠實校準
自算 chase 22% vs 官方 39.6%：好球帶劃定為公尺近似且真實帶高隨打者變動，故 Chase/Zone 類僅供參考並標註；權威 chase%/whiff% 以官方 advanced（上方 PR 區）為準。Swing/Whiff/Contact/CSW 不依賴劃帶故準確。

🤖 Generated with [Claude Code](https://claude.com/claude-code)