### PR TITLE
fix: 好球帶校準 + 逐球接每日增量

### DIFF
--- a/src/cpbl/api/main.py
+++ b/src/cpbl/api/main.py
@@ -697,7 +697,7 @@ def player_discipline(
               count(*) FILTER (WHERE NOT iz) ozone
             FROM (
               SELECT pitch_call,
-                     (abs(plate_loc_side) <= 0.25 AND plate_loc_height BETWEEN 0.45 AND 1.05) iz,
+                     (abs(plate_loc_side) <= 0.21 AND plate_loc_height BETWEEN 0.5 AND 1.0) iz,
                      (pitch_call IN {_SWING}) sw0
               FROM cpbl.pitch_tracking
               WHERE {col} = %s AND year = %s AND plate_loc_side IS NOT NULL

--- a/src/cpbl/ingest/run_refresh_recent.py
+++ b/src/cpbl/ingest/run_refresh_recent.py
@@ -26,6 +26,7 @@ from cpbl.ingest import cpbl_player_detail
 from cpbl.ingest.cpbl_advanced import scrape_advanced
 from cpbl.ingest.cpbl_fighting import YEAR_CAREER, scrape_matchups
 from cpbl.ingest.cpbl_gamelog import scrape_gamelogs
+from cpbl.ingest.cpbl_pitch_tracking import scrape_pitches
 from cpbl.ingest.cpbl_site import lineup_acnts, scrape_games
 from cpbl.ingest.cpbl_stats import scrape_all
 
@@ -66,9 +67,11 @@ def _incremental_detail(year: int, days: list[date], delay: float = 1.2) -> dict
     d = cpbl_player_detail.scrape(delay=delay, batter_ids=rb, pitcher_ids=rp)
     # 官方進階：當日上場選手（打者進攻 / 投手被打）
     adv = scrape_advanced(year, [(a, "batting") for a in rb] + [(a, "pitching") for a in rp], delay=delay)
+    # 逐球 TrackMan：當日上場投手（自其頁面，當天場次仍在視窗內）
+    pitches = scrape_pitches(rp, delay=delay) if rp else {"pitchers": 0, "pitches": 0}
     return {"completed_games": len(snos), "gamelog": gamelog,
             "lineup_batters": len(rb), "lineup_pitchers": len(rp),
-            "matchup_rows": m, "advanced": adv, **d}
+            "matchup_rows": m, "advanced": adv, "pitches": pitches, **d}
 
 
 def _recent_counts(year: int, days: list[date]) -> list[tuple[date, int, int]]:

--- a/web/src/app/players/[id]/page.tsx
+++ b/web/src/app/players/[id]/page.tsx
@@ -398,7 +398,7 @@ export default function PlayerPage() {
                   <XAxis type="number" dataKey="x" domain={[-0.8, 0.8]} {...axis} tickFormatter={() => ""} />
                   <YAxis type="number" dataKey="y" domain={[-0.2, 1.6]} {...axis} tickFormatter={() => ""} />
                   <ZAxis range={[18, 18]} />
-                  <ReferenceArea x1={-0.25} x2={0.25} y1={0.45} y2={1.05}
+                  <ReferenceArea x1={-0.21} x2={0.21} y1={0.5} y2={1.0}
                     stroke="rgba(255,255,255,0.45)" fill="rgba(255,255,255,0.04)" />
                   <Tooltip {...tooltipStyle} cursor={{ strokeDasharray: "3 3" }} />
                   <Scatter name="未揮棒" data={disc.points.filter((p) => !p.sw)} fill="rgba(255,255,255,0.25)" />


### PR DESCRIPTION
好球帶以全打者校準（side 0.21、高 0.5–1.0）；逐球 TrackMan 接進 cpbl-refresh-recent 增量（當日上場投手），確保前向完整。Chase/Zone 仍為近似，權威用官方 advanced。

🤖 Generated with [Claude Code](https://claude.com/claude-code)