### PR TITLE
feat: 逐場球員box + 2025季 + 季後賽game（資料盤點補爬）

### DIFF
--- a/migrations/019_game_box.sql
+++ b/migrations/019_game_box.sql
@@ -1,0 +1,76 @@
+-- 逐場球員 box score（每場每位選手的打擊/投球成績）。來源 box/getlive 的
+-- BattingJson / PitchingJson（與 scoreboard/livelog 同一請求）。HitCnt=打數、HittingCnt=安打。
+CREATE TABLE IF NOT EXISTS cpbl.batting_gamelog (
+    year               smallint NOT NULL,
+    kind_code          text     NOT NULL,
+    game_sno           int      NOT NULL,
+    hitter_acnt        text     NOT NULL,
+    hitter_name        text,
+    visiting_home_type text,
+    uniform_no         text,
+    role_type          text,    -- 先發 / 替補
+    plate_appearances  int,
+    at_bats            int,     -- HitCnt
+    hits               int,     -- HittingCnt
+    rbi                int,
+    runs               int,
+    singles            int,
+    doubles            int,
+    triples            int,
+    home_runs          int,
+    grand_slam         int,
+    total_bases        int,
+    gidp               int,
+    sac_hit            int,
+    sac_fly            int,
+    bb                 int,
+    ibb                int,
+    hbp                int,
+    so                 int,
+    sb                 int,
+    cs                 int,
+    lob                int,
+    errors             int,
+    gw_rbi             int,
+    is_mvp             boolean,
+    PRIMARY KEY (year, kind_code, game_sno, hitter_acnt)
+);
+
+CREATE TABLE IF NOT EXISTS cpbl.pitching_gamelog (
+    year                smallint NOT NULL,
+    kind_code           text     NOT NULL,
+    game_sno            int      NOT NULL,
+    pitcher_acnt        text     NOT NULL,
+    pitcher_name        text,
+    visiting_home_type  text,
+    uniform_no          text,
+    role_type           text,
+    game_result         text,    -- 勝/敗/中繼/救援…
+    is_complete_game    boolean,
+    is_shutout          boolean,
+    inning_pitched_cnt  int,
+    inning_pitched_div3 int,
+    plate_appearances   int,
+    pitch_cnt           int,
+    strike_cnt          int,
+    ball_cnt            int,
+    hits                int,
+    home_runs           int,
+    sac_hit             int,
+    sac_fly             int,
+    bb                  int,
+    ibb                 int,
+    hbp                 int,
+    so                  int,
+    wild_pitch          int,
+    balk                int,
+    runs                int,
+    earned_runs         int,
+    relief_point        int,
+    max_speed           real,    -- 該場最快球速 GameHigherSpeedPitch
+    is_mvp              boolean,
+    PRIMARY KEY (year, kind_code, game_sno, pitcher_acnt)
+);
+
+CREATE INDEX IF NOT EXISTS idx_bgl_hitter ON cpbl.batting_gamelog (hitter_acnt, year);
+CREATE INDEX IF NOT EXISTS idx_pgl_pitcher ON cpbl.pitching_gamelog (pitcher_acnt, year);

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,7 @@ cpbl-refresh-recent = "cpbl.ingest.run_refresh_recent:main"
 cpbl-scrape-gamelog = "cpbl.ingest.run_scrape_gamelog:main"
 cpbl-scrape-advanced = "cpbl.ingest.run_scrape_advanced:main"
 cpbl-scrape-pitches = "cpbl.ingest.run_scrape_pitches:main"
+cpbl-backfill-season = "cpbl.ingest.run_backfill_season:main"
 cpbl-build-features = "cpbl.features.run_build_features:main"
 cpbl-train = "cpbl.models.train:main"
 

--- a/scripts/refresh-cpbl-prod.sh
+++ b/scripts/refresh-cpbl-prod.sh
@@ -102,6 +102,18 @@ if [ -n "${WITH_DETAIL:-}" ]; then
     pitch_call auto_pitch_type tagged_pitch_type rel_speed spin_rate rel_side rel_height extension \
     zone_speed plate_loc_side plate_loc_height hit_exit_speed hit_launch_angle hit_direction \
     hit_distance hit_hang_time
+  sync_table batting_gamelog "year,kind_code,game_sno,hitter_acnt" \
+    hitter_name visiting_home_type uniform_no role_type plate_appearances at_bats hits rbi runs \
+    singles doubles triples home_runs grand_slam total_bases gidp sac_hit sac_fly bb ibb hbp so sb cs \
+    lob errors gw_rbi is_mvp
+  sync_table pitching_gamelog "year,kind_code,game_sno,pitcher_acnt" \
+    pitcher_name visiting_home_type uniform_no role_type game_result is_complete_game is_shutout \
+    inning_pitched_cnt inning_pitched_div3 plate_appearances pitch_cnt strike_cnt ball_cnt hits \
+    home_runs sac_hit sac_fly bb ibb hbp so wild_pitch balk runs earned_runs relief_point max_speed is_mvp
+  sync_table batting_seasons "player_id,year,team_id" \
+    team_name g pa ab rbi r h b1 b2 b3 hr tb so sb gidp sh sf bb ibb hbp cs go fo
+  sync_table pitching_seasons "player_id,year,team_id" \
+    team_name g gs gr cg sho nbb w l sv hld ip bf np h hr bb ibb hbp so wp bk r er go fo
 fi
 
 echo "==> 3/3 VPS 重建賽果特徵"

--- a/src/cpbl/ingest/cpbl_gamelog.py
+++ b/src/cpbl/ingest/cpbl_gamelog.py
@@ -62,6 +62,55 @@ def _livelog_rows(year: int, kind: str, sno: int, data: list[dict]) -> list[tupl
     return out
 
 
+def _bbox_rows(year: int, kind: str, sno: int, data: list[dict]) -> list[tuple]:
+    out = []
+    for r in data:
+        if not r.get("HitterAcnt"):
+            continue
+        out.append((
+            year, kind, sno, r.get("HitterAcnt"), r.get("HitterName"), r.get("VisitingHomeType"),
+            r.get("HitterUniformNo"), r.get("RoleType"), _i(r.get("PlateAppearances")),
+            _i(r.get("HitCnt")), _i(r.get("HittingCnt")), _i(r.get("RunBattedINCnt")), _i(r.get("ScoreCnt")),
+            _i(r.get("OneBaseHitCnt")), _i(r.get("TwoBaseHitCnt")), _i(r.get("ThreeBaseHitCnt")),
+            _i(r.get("HomeRunCnt")), _i(r.get("GrandSlamHomerunCnt")), _i(r.get("TotalBases")),
+            _i(r.get("DoublePlayBatCnt")), _i(r.get("SacrificeHitCnt")), _i(r.get("SacrificeFlyCnt")),
+            _i(r.get("BasesONBallsCnt")), _i(r.get("IntentionalBasesONBallsCnt")), _i(r.get("HitBYPitchCnt")),
+            _i(r.get("StrikeOutCnt")), _i(r.get("StealBaseOKCnt")), _i(r.get("StealBaseFailCnt")),
+            _i(r.get("Lobs")), _i(r.get("ErrorCnt")), _i(r.get("GameWinningRbiCnt")), _b(r.get("IsMvp")),
+        ))
+    return out
+
+
+def _pbox_rows(year: int, kind: str, sno: int, data: list[dict]) -> list[tuple]:
+    out = []
+    for r in data:
+        if not r.get("PitcherAcnt"):
+            continue
+        out.append((
+            year, kind, sno, r.get("PitcherAcnt"), r.get("PitcherName"), r.get("VisitingHomeType"),
+            r.get("PitcherUniformNo"), r.get("RoleType"), r.get("GameResult"),
+            _b(r.get("IsCompleteGame")), _b(r.get("IsShoutOut")),
+            _i(r.get("InningPitchedCnt")), _i(r.get("InningPitchedDiv3Cnt")), _i(r.get("PlateAppearances")),
+            _i(r.get("PitchCnt")), _i(r.get("StrikeCnt")), _i(r.get("BallCnt")), _i(r.get("HittingCnt")),
+            _i(r.get("HomeRunCnt")), _i(r.get("SacrificeHitCnt")), _i(r.get("SacrificeFlyCnt")),
+            _i(r.get("BasesONBallsCnt")), _i(r.get("IntentionalBasesONBallsCnt")), _i(r.get("HitBYPitchCnt")),
+            _i(r.get("StrikeOutCnt")), _i(r.get("WildPitchCnt")), _i(r.get("BalkCnt")),
+            _i(r.get("RunCnt")), _i(r.get("EarnedRunCnt")), _i(r.get("ReliefPointCnt")),
+            _f(r.get("GameHigherSpeedPitch")), _b(r.get("IsMvp")),
+        ))
+    return out
+
+
+_f = lambda v: (float(v) if v not in (None, "") else None)  # noqa: E731
+
+_BBOX_COLS = ("year,kind_code,game_sno,hitter_acnt,hitter_name,visiting_home_type,uniform_no,role_type,"
+              "plate_appearances,at_bats,hits,rbi,runs,singles,doubles,triples,home_runs,grand_slam,"
+              "total_bases,gidp,sac_hit,sac_fly,bb,ibb,hbp,so,sb,cs,lob,errors,gw_rbi,is_mvp")
+_PBOX_COLS = ("year,kind_code,game_sno,pitcher_acnt,pitcher_name,visiting_home_type,uniform_no,role_type,"
+              "game_result,is_complete_game,is_shutout,inning_pitched_cnt,inning_pitched_div3,"
+              "plate_appearances,pitch_cnt,strike_cnt,ball_cnt,hits,home_runs,sac_hit,sac_fly,bb,ibb,hbp,"
+              "so,wild_pitch,balk,runs,earned_runs,relief_point,max_speed,is_mvp")
+
 _SB_COLS = ("year,kind_code,game_sno,team_no,inning_seq,visiting_home_type,team_name,"
             "score_cnt,hitting_cnt,error_cnt")
 _LL_COLS = ("year,kind_code,game_sno,main_event_no,inning_seq,visiting_home_type,batting_order,"
@@ -90,7 +139,7 @@ def _upsert(table: str, cols: str, n_pk: int, records: list[tuple]) -> int:
 def scrape_gamelogs(year: int, snos: list[int], kind_code: str = KIND_REGULAR,
                     delay: float = 0.7) -> dict:
     """抓指定場次的賽況並 UPSERT。回傳 {games, scoreboard, livelog}。"""
-    out = {"games": 0, "scoreboard": 0, "livelog": 0}
+    out = {"games": 0, "scoreboard": 0, "livelog": 0, "batting_box": 0, "pitching_box": 0}
     if not snos:
         return out
     client = httpx.Client(
@@ -124,12 +173,18 @@ def scrape_gamelogs(year: int, snos: list[int], kind_code: str = KIND_REGULAR,
                 continue
             sb = json.loads(payload.get("ScoreboardJson") or "[]")
             ll = json.loads(payload.get("LiveLogJson") or "[]")
+            bb = json.loads(payload.get("BattingJson") or "[]")
+            pp = json.loads(payload.get("PitchingJson") or "[]")
             out["scoreboard"] += _upsert("game_scoreboard", _SB_COLS, 5,
                                          _scoreboard_rows(year, kind_code, sno, sb))
             out["livelog"] += _upsert("game_livelog", _LL_COLS, 4,
                                       _livelog_rows(year, kind_code, sno, ll))
+            out["batting_box"] += _upsert("batting_gamelog", _BBOX_COLS, 4,
+                                          _bbox_rows(year, kind_code, sno, bb))
+            out["pitching_box"] += _upsert("pitching_gamelog", _PBOX_COLS, 4,
+                                           _pbox_rows(year, kind_code, sno, pp))
             out["games"] += 1
-            log.info("sno=%s scoreboard=%d livelog=%d", sno, len(sb), len(ll))
+            log.info("sno=%s scoreboard=%d livelog=%d box(打%d投%d)", sno, len(sb), len(ll), len(bb), len(pp))
     finally:
         client.close()
     return out

--- a/src/cpbl/ingest/cpbl_season_backfill.py
+++ b/src/cpbl/ingest/cpbl_season_backfill.py
@@ -1,0 +1,115 @@
+"""以官方 teamscore 回填某一年的 season-level 彙總到 *_seasons（opendata 未涵蓋的年份，如 2025）。
+
+teamscore 欄位與 *_seasons 幾乎一一對應（故四為全形括號需解析；team_id 用 team_code）。
+冪等 UPSERT。僅補打者與投手季（ML 預測用）。
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+
+import httpx
+
+from cpbl.db import conn
+from cpbl.ingest.cpbl_stats import (
+    CLUB_NOS,
+    PIT_TS_IDX,
+    TS_IDX,
+    UA,
+    _num,
+    _teamscore_post,
+    _teamscore_token,
+)
+
+log = logging.getLogger("cpbl.seasonbf")
+
+CLUB_NAME = {"AAA": "味全龍", "ACN": "中信兄弟", "ADD": "統一7-ELEVEn獅",
+             "AEO": "富邦悍將", "AJL": "樂天桃猿", "AKP": "台鋼雄鷹"}
+
+
+def _int(v) -> int | None:
+    return int(v) if v is not None else None
+
+
+def _paren_int(cell: str) -> int | None:
+    m = re.search(r"\d+", cell or "")
+    return int(m.group()) if m else None
+
+
+def _rows(html: str, idx: dict, n_min: int):
+    for tr in re.findall(r"<tr>(.*?)</tr>", html, re.S):
+        mid = re.search(r"/team/person\?acnt=(\d+)", tr)
+        if not mid:
+            continue
+        nums = [n.strip() for n in re.findall(r'<td class="num">(.*?)</td>', tr, re.S)]
+        if len(nums) < n_min:
+            continue
+        yield mid.group(1), nums
+
+
+def backfill_batting_season(year: int) -> int:
+    records = []
+    client = httpx.Client(timeout=30.0, headers={"User-Agent": UA}, follow_redirects=True)
+    try:
+        token = _teamscore_token(client)
+        for club in CLUB_NOS:
+            tc, html = f"{club}011", _teamscore_post(client, token, club, "01", year, "A")
+
+            for pid, nums in _rows(html, TS_IDX, 28):
+                def b(k):
+                    return _num(nums[TS_IDX[k]])
+                records.append((
+                    pid, year, tc, CLUB_NAME.get(club),
+                    _int(b("g")), _int(b("pa")), _int(b("ab")), _int(b("rbi")), _int(b("r")), _int(b("h")),
+                    _int(_num(nums[6])), _int(b("b2")), _int(b("b3")), _int(b("hr")), _int(b("tb")),
+                    _int(b("so")), _int(b("sb")), _int(b("gidp")), _int(b("sh")), _int(b("sf")),
+                    _int(b("bb")), _paren_int(nums[TS_IDX["ibb"]]), _int(b("hbp")), _int(b("cs")),
+                    _int(b("go")), _int(b("ao")),
+                ))
+    finally:
+        client.close()
+    cols = ("player_id,year,team_id,team_name,g,pa,ab,rbi,r,h,b1,b2,b3,hr,tb,so,sb,gidp,sh,sf,"
+            "bb,ibb,hbp,cs,go,fo")
+    return _upsert("batting_seasons", cols, records)
+
+
+def backfill_pitching_season(year: int) -> int:
+    records = []
+    client = httpx.Client(timeout=30.0, headers={"User-Agent": UA}, follow_redirects=True)
+    try:
+        token = _teamscore_token(client)
+        for club in CLUB_NOS:
+            tc, html = f"{club}011", _teamscore_post(client, token, club, "02", year, "A")
+
+            for pid, nums in _rows(html, PIT_TS_IDX, 28):
+                def p(k):
+                    return _num(nums[PIT_TS_IDX[k]])
+                records.append((
+                    pid, year, tc, CLUB_NAME.get(club),
+                    _int(p("g")), _int(p("gs")), _int(p("gr")), _int(p("cg")), _int(p("sho")),
+                    _int(_num(nums[5])), _int(p("w")), _int(p("l")), _int(p("sv")), _int(p("hld")),
+                    p("ip"), _int(p("pa")), _int(p("np")), _int(p("h")), _int(p("hr")),
+                    _int(p("bb")), _paren_int(nums[PIT_TS_IDX["ibb"]]), _int(p("hbp")), _int(p("so")),
+                    _int(p("wp")), _int(p("bk")), _int(p("r")), _int(p("er")), _int(p("go")), _int(p("ao")),
+                ))
+    finally:
+        client.close()
+    cols = ("player_id,year,team_id,team_name,g,gs,gr,cg,sho,nbb,w,l,sv,hld,ip,bf,np,h,hr,"
+            "bb,ibb,hbp,so,wp,bk,r,er,go,fo")
+    return _upsert("pitching_seasons", cols, records)
+
+
+def _upsert(table: str, cols: str, records: list[tuple]) -> int:
+    if not records:
+        return 0
+    col_list = [c.strip() for c in cols.split(",")]
+    ph = "(" + ",".join(["%s"] * len(col_list)) + ")"
+    updates = ", ".join(f"{c}=EXCLUDED.{c}" for c in col_list[3:])
+    with conn() as c:
+        c.cursor().executemany(
+            f"INSERT INTO cpbl.{table} ({cols}) VALUES {ph} "
+            f"ON CONFLICT (player_id, year, team_id) DO UPDATE SET {updates}",
+            records,
+        )
+    return len(records)

--- a/src/cpbl/ingest/run_backfill_season.py
+++ b/src/cpbl/ingest/run_backfill_season.py
@@ -1,0 +1,28 @@
+"""CLI：以官方 teamscore 回填某年的 season-level 彙總（opendata 未涵蓋年份，如 2025）。
+
+    uv run cpbl-backfill-season 2025
+"""
+
+from __future__ import annotations
+
+import logging
+import sys
+
+from cpbl.db import migrate
+from cpbl.ingest.cpbl_season_backfill import backfill_batting_season, backfill_pitching_season
+
+
+def main() -> None:
+    logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(name)s | %(message)s")
+    if len(sys.argv) < 2:
+        print("用法：cpbl-backfill-season <YEAR>")
+        sys.exit(1)
+    year = int(sys.argv[1])
+    migrate()
+    b = backfill_batting_season(year)
+    p = backfill_pitching_season(year)
+    logging.getLogger("cpbl.seasonbf").info("done %d: batting=%d pitching=%d", year, b, p)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/cpbl/ingest/run_scrape.py
+++ b/src/cpbl/ingest/run_scrape.py
@@ -1,6 +1,6 @@
-"""CLI：爬官網逐場賽程/結果。
+"""CLI：爬官網逐場賽程/結果（一軍：例行賽 A + 總冠軍賽 C + 季後挑戰賽 E）。
 
-    uv run cpbl-scrape-games            # 預設抓當年（一軍例行賽）
+    uv run cpbl-scrape-games            # 預設抓當年
     uv run cpbl-scrape-games 2020 2024  # 指定年份區間
 """
 
@@ -13,6 +13,8 @@ from datetime import date
 from cpbl.db import migrate
 from cpbl.ingest.cpbl_site import scrape_games
 
+KINDS = ["A", "C", "E"]  # 一軍例行賽 / 總冠軍賽 / 季後挑戰賽
+
 
 def main() -> None:
     logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(name)s | %(message)s")
@@ -24,9 +26,16 @@ def main() -> None:
     end = int(args[1]) if len(args) >= 2 else start
 
     migrate()
-    log.info("scraping games %s–%s …", start, end)
-    totals = scrape_games(start, end)
-    log.info("done. totals: %s (sum=%d)", totals, sum(totals.values()))
+    grand = 0
+    for kind in KINDS:
+        try:
+            totals = scrape_games(start, end, kind)
+            n = sum(totals.values())
+            grand += n
+            log.info("kind=%s %s–%s: %s", kind, start, end, totals)
+        except Exception as e:  # noqa: BLE001 — 某賽別當年無資料時容錯
+            log.warning("kind=%s 略過：%s", kind, e)
+    log.info("done. 合計 %d 場", grand)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
資料盤點後補爬三項缺口：

## A 逐場球員 box score
`batting_gamelog` / `pitching_gamelog`（migration 019）：每場每位選手打擊/投球成績，自 box/getlive 的 BattingJson/PitchingJson 解析（與 scoreboard/livelog 同一請求，零額外成本）。含先發/替補、MVP、該場最速球、勝敗。本季 151 場、打者 3471 / 投手 1312。

## B 2025 完整季
opendata 僅到 2024；以官方 teamscore 回填 2025 到 `batting_seasons`/`pitching_seasons`（cpbl-backfill-season）。讓成績預測模型可用到最新完整季（batting 174 / pitching 168）。

## C 季後賽/總冠軍賽 game
`cpbl-scrape-games` 擴充為 A+C+E；`games` 新增 C(17)/E(10) 逐場結果。

## infra
prod 同步腳本加入上述新表（prod 海外 IP 無法爬，季資料須同步上線）。

## 註
皆為資料層；前端呈現（逐場成績表、季史、季後賽）為後續。derivable 類（stats /rankings、球種庫）不爬。

🤖 Generated with [Claude Code](https://claude.com/claude-code)