### PR TITLE
feat: 官方球隊戰績（和局/勝差/H2H/主客場/上下半季）

### DIFF
--- a/migrations/020_team_standings.sql
+++ b/migrations/020_team_standings.sql
@@ -1,0 +1,24 @@
+-- 官方球隊戰績（standings/seasonaction）。含和局、勝差、淘汰指數、對戰各隊(H2H)、
+-- 主客場戰績、連勝連敗、近十場；分上半季(1)/下半季(2)/全年(0)。
+CREATE TABLE IF NOT EXISTS cpbl.team_standings (
+    year         smallint NOT NULL,
+    kind_code    text     NOT NULL,
+    season_code  smallint NOT NULL,   -- 0=全年 1=上半季 2=下半季
+    team_code    text     NOT NULL,
+    team_name    text,
+    rank         int,
+    g            int,
+    w            int,
+    t            int,
+    l            int,
+    win_pct      real,
+    gb           real,                 -- 勝差（領先隊為 0）
+    elim         text,                 -- 淘汰指數（原樣）
+    home_record  text,                 -- 主場 勝-和-敗
+    away_record  text,                 -- 客場 勝-和-敗
+    streak       text,                 -- 連勝/連敗（如 勝3 / 敗2）
+    last10       text,                 -- 近十場 勝-和-敗
+    h2h          jsonb,                -- 對戰各隊 {team_code: "勝-和-敗"}
+    updated_at   timestamptz NOT NULL DEFAULT now(),
+    PRIMARY KEY (year, kind_code, season_code, team_code)
+);

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,6 +27,7 @@ cpbl-scrape-gamelog = "cpbl.ingest.run_scrape_gamelog:main"
 cpbl-scrape-advanced = "cpbl.ingest.run_scrape_advanced:main"
 cpbl-scrape-pitches = "cpbl.ingest.run_scrape_pitches:main"
 cpbl-backfill-season = "cpbl.ingest.run_backfill_season:main"
+cpbl-scrape-standings = "cpbl.ingest.run_scrape_standings:main"
 cpbl-build-features = "cpbl.features.run_build_features:main"
 cpbl-train = "cpbl.models.train:main"
 

--- a/scripts/refresh-cpbl-prod.sh
+++ b/scripts/refresh-cpbl-prod.sh
@@ -67,6 +67,8 @@ sync_table batting_current "year,player_id" name team_code pa avg obp slg ops hr
   g ab r h b2 b3 rbi bb so sb cs tb gidp sh sf ibb hbp go ao goao
 sync_table fielding_current "year,player_id,pos" name team_code g tc po a e dp fpct
 sync_table team_current "year,team_code" name bat_avg bat_obp bat_slg bat_ops bat_hr pit_era pit_whip
+sync_table team_standings "year,kind_code,season_code,team_code" \
+  team_name rank g w t l win_pct gb elim home_record away_record streak last10 h2h
 
 if [ -n "${WITH_DETAIL:-}" ]; then
   sync_table batter_pitcher_matchups "year,kind_code,hitter_acnt,pitcher_acnt" \

--- a/src/cpbl/api/main.py
+++ b/src/cpbl/api/main.py
@@ -724,3 +724,20 @@ def player_discipline(
         points = [{"x": float(s), "y": float(h), "sw": sw, "wh": wh}
                   for s, h, sw, wh in cur.fetchall()]
     return {"player_id": player_id, "role": role, "summary": summary, "points": points}
+
+
+@app.get("/api/v1/standings")
+def official_standings(
+    season: int = Query(DEFAULT_SEASON),
+    season_code: int = Query(0, ge=0, le=2, description="0=全年 1=上半季 2=下半季"),
+    kind_code: str = Query("A"),
+) -> dict:
+    """官方球隊戰績（含和局/勝差/淘汰指數/H2H/主客場/連勝敗/近十場；分上下半季）。"""
+    with conn() as c:
+        cur = c.cursor()
+        cur.execute(
+            "SELECT * FROM cpbl.team_standings WHERE year=%s AND kind_code=%s AND season_code=%s "
+            "ORDER BY rank",
+            (season, kind_code, season_code),
+        )
+        return {"season": season, "season_code": season_code, "items": _dicts(cur)}

--- a/src/cpbl/ingest/cpbl_standings.py
+++ b/src/cpbl/ingest/cpbl_standings.py
@@ -1,0 +1,108 @@
+"""官方球隊戰績爬蟲（standings/seasonaction，含上下半季）。
+
+回傳 HTML 表格；每列 16 cell：排名+隊名 / 出賽 / 勝-和-敗 / 勝率 / 勝差 / 淘汰指數 /
+對戰各隊×6 / 主場 / 客場 / 連勝敗 / 近十場。SeasonCode：0全年 1上半 2下半。冪等 UPSERT。
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import re
+
+import httpx
+
+from cpbl.db import conn
+
+log = logging.getLogger("cpbl.standings")
+
+BASE = "https://www.cpbl.com.tw"
+PAGE = f"{BASE}/standings/season"
+ACTION = f"{BASE}/standings/seasonaction"
+UA = "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36"
+_TOKEN_RE = re.compile(r"RequestVerificationToken:\s*'([^']+)'")
+
+# H2H 欄位固定順序（對應表頭）→ team_code
+H2H_ORDER = ["AAA011", "AEO011", "AKP011", "ADD011", "AJL011", "ACN011"]
+NAME_CODE = {"味全龍": "AAA011", "中信兄弟": "ACN011", "統一7-ELEVEn獅": "ADD011",
+             "富邦悍將": "AEO011", "樂天桃猿": "AJL011", "台鋼雄鷹": "AKP011"}
+_TXT = re.compile(r"<[^>]+>")
+
+
+def _clean(html: str) -> str:
+    return re.sub(r"\s+", "", _TXT.sub("", html)).replace("\xa0", "")
+
+
+def _wtl(s: str) -> tuple[int | None, int | None, int | None]:
+    m = re.match(r"(\d+)-(\d+)-(\d+)", s or "")
+    return (int(m.group(1)), int(m.group(2)), int(m.group(3))) if m else (None, None, None)
+
+
+def fetch_standings(year: int, season_code: int, kind_code: str = "A") -> list[tuple]:
+    client = httpx.Client(timeout=30.0, headers={"User-Agent": UA, "X-Requested-With": "XMLHttpRequest"},
+                          follow_redirects=True)
+    try:
+        token = _TOKEN_RE.search(client.get(PAGE).text).group(1)
+        html = client.post(ACTION, data={"Year": str(year), "KindCode": kind_code,
+                                         "SeasonCode": str(season_code)},
+                           headers={"RequestVerificationToken": token}).text
+    finally:
+        client.close()
+    first = html[: html.find("</table>") + 8]  # 只取第一張（戰績）表
+    records = []
+    for tr in re.findall(r"<tr>(.*?)</tr>", first, re.S):
+        tds = re.findall(r"<td[^>]*>(.*?)</td>", tr, re.S)
+        if len(tds) < 16:
+            continue
+        name = next((n for n in NAME_CODE if n in tr), None)
+        if not name:
+            continue
+        code = NAME_CODE[name]
+        rank_m = re.search(r'rank">(\d+)', tds[0])
+        g = _clean(tds[1])
+        w, t, l = _wtl(_clean(tds[2]))
+        wp = _clean(tds[3])
+        gb_raw = _clean(tds[4])
+        h2h = {H2H_ORDER[i]: _clean(tds[6 + i]) for i in range(6)
+               if H2H_ORDER[i] != code and re.match(r"\d+-\d+-\d+", _clean(tds[6 + i]))}
+        records.append((
+            year, kind_code, season_code, code, name,
+            int(rank_m.group(1)) if rank_m else None, int(g) if g.isdigit() else None,
+            w, t, l, float(wp) if re.match(r"[0-9.]+$", wp) else None,
+            0.0 if gb_raw in ("-", "") else (float(gb_raw) if re.match(r"[0-9.]+$", gb_raw) else None),
+            _clean(tds[5]) or None, _clean(tds[12]) or None, _clean(tds[13]) or None,
+            _clean(tds[14]) or None, _clean(tds[15]) or None, json.dumps(h2h, ensure_ascii=False),
+        ))
+    return records
+
+
+_COLS = ("year,kind_code,season_code,team_code,team_name,rank,g,w,t,l,win_pct,gb,elim,"
+         "home_record,away_record,streak,last10,h2h")
+
+
+def upsert_standings(records: list[tuple]) -> int:
+    if not records:
+        return 0
+    cols = [c.strip() for c in _COLS.split(",")]
+    ph = "(" + ",".join(["%s"] * (len(cols) - 1) + ["%s::jsonb"]) + ")"
+    updates = ", ".join(f"{c}=EXCLUDED.{c}" for c in cols[4:]) + ", updated_at=now()"
+    with conn() as c:
+        c.cursor().executemany(
+            f"INSERT INTO cpbl.team_standings ({_COLS}) VALUES {ph} "
+            f"ON CONFLICT (year, kind_code, season_code, team_code) DO UPDATE SET {updates}",
+            records,
+        )
+    return len(records)
+
+
+def scrape_standings(year: int, kind_code: str = "A") -> dict:
+    """抓全年(0)+上半(1)+下半(2)。回傳 {season_code: 隊數}。"""
+    out = {}
+    for sc in (0, 1, 2):
+        try:
+            n = upsert_standings(fetch_standings(year, sc, kind_code))
+            out[sc] = n
+            log.info("standings %s SeasonCode=%s: %d 隊", year, sc, n)
+        except Exception as e:  # noqa: BLE001
+            log.warning("SeasonCode=%s 略過：%s", sc, e)
+    return out

--- a/src/cpbl/ingest/run_refresh_recent.py
+++ b/src/cpbl/ingest/run_refresh_recent.py
@@ -28,6 +28,7 @@ from cpbl.ingest.cpbl_fighting import YEAR_CAREER, scrape_matchups
 from cpbl.ingest.cpbl_gamelog import scrape_gamelogs
 from cpbl.ingest.cpbl_pitch_tracking import scrape_pitches
 from cpbl.ingest.cpbl_site import lineup_acnts, scrape_games
+from cpbl.ingest.cpbl_standings import scrape_standings
 from cpbl.ingest.cpbl_stats import scrape_all
 
 log = logging.getLogger("cpbl.refresh")
@@ -114,6 +115,7 @@ def main() -> None:
     try:
         games = scrape_games(year, year)
         stats = scrape_all(year, year, year)
+        scrape_standings(year)  # 官方球隊戰績（含和局/勝差/上下半季），輕量每次更新
         detail_inc = {} if skip_detail else _incremental_detail(year, [yesterday, today])
     except Exception as e:  # noqa: BLE001 — 失敗也要留痕，避免無聲缺漏
         log.error("抓取失敗：%s", e)

--- a/src/cpbl/ingest/run_scrape_standings.py
+++ b/src/cpbl/ingest/run_scrape_standings.py
@@ -1,0 +1,26 @@
+"""CLI：爬官方球隊戰績（含上下半季：和局/勝差/淘汰指數/H2H/主客場/連勝敗/近十場）。
+
+    uv run cpbl-scrape-standings          # 當年
+    uv run cpbl-scrape-standings 2025     # 指定年
+"""
+
+from __future__ import annotations
+
+import logging
+import sys
+from datetime import date
+
+from cpbl.db import migrate
+from cpbl.ingest.cpbl_standings import scrape_standings
+
+
+def main() -> None:
+    logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(name)s | %(message)s")
+    year = int(sys.argv[1]) if len(sys.argv) >= 2 else date.today().year
+    migrate()
+    out = scrape_standings(year)
+    logging.getLogger("cpbl.standings").info("done %d: %s", year, out)
+
+
+if __name__ == "__main__":
+    main()

--- a/web/src/app/page.tsx
+++ b/web/src/app/page.tsx
@@ -1,59 +1,84 @@
+import Link from "next/link";
 import { api } from "@/lib/api";
 
-// 即時渲染（不在 build 時預抓 API）；fetch 仍以 revalidate 快取 10 分鐘。
 export const dynamic = "force-dynamic";
 
-export default async function Home() {
-  const { season, standings } = await api.standings();
+const SEGS = [
+  { v: 0, label: "全年" },
+  { v: 1, label: "上半季" },
+  { v: 2, label: "下半季" },
+];
+
+export default async function Home({ searchParams }: { searchParams: Promise<{ seg?: string }> }) {
+  const { seg = "0" } = await searchParams;
+  const segCode = Number(seg) || 0;
+  const [{ season, items }, derived] = await Promise.all([
+    api.officialStandings(segCode),
+    api.standings(),
+  ]);
+  // 團隊 OPS/ERA/WHIP 來自即時彙整端點，依 code 併入
+  const adv = new Map(derived.standings.map((d) => [d.code, d]));
 
   return (
     <div>
-      <header className="mb-6">
+      <header className="mb-5">
         <h1 className="text-2xl font-bold">{season} 球季 · 本季戰績</h1>
-        <p className="mt-2 text-sm text-white/50">
-          由官網逐場結果即時彙整(資料更新至最近一次爬蟲)。場均得分 / 失分為攻守指標。
-        </p>
+        <p className="mt-2 text-sm text-white/50">官方戰績（含和局/勝差/連勝敗/主客場/近十場）。團隊 OPS/ERA/WHIP 為攻守指標。</p>
       </header>
 
-      <div className="overflow-x-auto rounded-xl border border-white/10">
-        <table className="w-full text-sm">
-          <thead className="bg-white/5 text-left text-white/50">
-            <tr>
-              <th className="px-3 py-3 font-medium">#</th>
-              <th className="px-3 py-3 font-medium">球隊</th>
-              <th className="px-3 py-3 text-right font-medium">勝–敗</th>
-              <th className="px-3 py-3 text-right font-medium">勝率</th>
-              <th className="px-3 py-3 text-right font-medium">得失差</th>
-              <th className="px-3 py-3 text-right font-medium" title="團隊整體攻擊指數">團隊OPS</th>
-              <th className="px-3 py-3 text-right font-medium" title="團隊防禦率">ERA</th>
-              <th className="px-3 py-3 text-right font-medium" title="團隊每局被上壘率">WHIP</th>
-              <th className="px-3 py-3 text-right font-medium">近10</th>
-            </tr>
-          </thead>
-          <tbody className="font-mono tabular-nums">
-            {standings.map((t, i) => (
-              <tr key={t.code} className="border-t border-white/5 hover:bg-white/5">
-                <td className="px-3 py-3 text-white/40">{i + 1}</td>
-                <td className="px-3 py-3 font-sans">{t.name}</td>
-                <td className="px-3 py-3 text-right">
-                  {t.w}–{t.l}
-                </td>
-                <td className="px-3 py-3 text-right text-emerald-400">{t.win_pct.toFixed(3)}</td>
-                <td
-                  className={`px-3 py-3 text-right ${t.run_diff >= 0 ? "text-emerald-400/80" : "text-rose-400/80"}`}
-                >
-                  {t.run_diff >= 0 ? "+" : ""}
-                  {t.run_diff.toFixed(2)}
-                </td>
-                <td className="px-3 py-3 text-right">{t.ops?.toFixed(3) ?? "—"}</td>
-                <td className="px-3 py-3 text-right">{t.era?.toFixed(2) ?? "—"}</td>
-                <td className="px-3 py-3 text-right">{t.whip?.toFixed(2) ?? "—"}</td>
-                <td className="px-3 py-3 text-right text-white/50">{t.form}</td>
+      <nav className="mb-4 flex gap-2">
+        {SEGS.map((s) => (
+          <Link
+            key={s.v}
+            href={`/?seg=${s.v}`}
+            className={`rounded-full px-3 py-1 text-sm transition ${
+              segCode === s.v ? "bg-emerald-500 text-black" : "bg-white/5 text-white/60 hover:bg-white/10"
+            }`}
+          >
+            {s.label}
+          </Link>
+        ))}
+      </nav>
+
+      {items.length === 0 ? (
+        <p className="text-sm text-white/40">此區間尚無戰績（下半季可能未開始）。</p>
+      ) : (
+        <div className="overflow-x-auto rounded-xl border border-white/10">
+          <table className="w-full text-sm">
+            <thead className="bg-white/5 text-left text-white/50">
+              <tr>
+                {["#", "球隊", "出賽", "勝-和-敗", "勝率", "勝差", "連勝/敗", "主場", "客場", "近十場", "OPS", "ERA", "WHIP"].map(
+                  (h) => (
+                    <th key={h} className="whitespace-nowrap px-2.5 py-3 font-medium">{h}</th>
+                  ),
+                )}
               </tr>
-            ))}
-          </tbody>
-        </table>
-      </div>
+            </thead>
+            <tbody className="font-mono tabular-nums">
+              {items.map((t) => {
+                const a = adv.get(t.team_code);
+                return (
+                  <tr key={t.team_code} className="border-t border-white/5 hover:bg-white/5">
+                    <td className="px-2.5 py-2.5 text-white/40">{t.rank}</td>
+                    <td className="whitespace-nowrap px-2.5 py-2.5 font-sans">{t.team_name}</td>
+                    <td className="px-2.5 py-2.5 text-white/50">{t.g}</td>
+                    <td className="px-2.5 py-2.5">{t.w}-{t.t}-{t.l}</td>
+                    <td className="px-2.5 py-2.5 text-emerald-400">{t.win_pct?.toFixed(3) ?? "—"}</td>
+                    <td className="px-2.5 py-2.5 text-white/70">{t.gb === 0 ? "—" : t.gb}</td>
+                    <td className="px-2.5 py-2.5 text-white/60">{t.streak ?? "—"}</td>
+                    <td className="px-2.5 py-2.5 text-white/50">{t.home_record ?? "—"}</td>
+                    <td className="px-2.5 py-2.5 text-white/50">{t.away_record ?? "—"}</td>
+                    <td className="px-2.5 py-2.5 text-white/50">{t.last10 ?? "—"}</td>
+                    <td className="px-2.5 py-2.5">{a?.ops?.toFixed(3) ?? "—"}</td>
+                    <td className="px-2.5 py-2.5">{a?.era?.toFixed(2) ?? "—"}</td>
+                    <td className="px-2.5 py-2.5">{a?.whip?.toFixed(2) ?? "—"}</td>
+                  </tr>
+                );
+              })}
+            </tbody>
+          </table>
+        </div>
+      )}
     </div>
   );
 }

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -119,7 +119,28 @@ export type GameSummary = {
 };
 export type GamesRecentResponse = { season: number; items: GameSummary[] };
 
+export type OfficialStanding = {
+  team_code: string;
+  team_name: string;
+  rank: number;
+  g: number;
+  w: number;
+  t: number;
+  l: number;
+  win_pct: number | null;
+  gb: number | null;
+  elim: string | null;
+  home_record: string | null;
+  away_record: string | null;
+  streak: string | null;
+  last10: string | null;
+  h2h: Record<string, string> | null;
+};
+export type OfficialStandingsResponse = { season: number; season_code: number; items: OfficialStanding[] };
+
 export const api = {
+  officialStandings: (seg = 0) =>
+    get<OfficialStandingsResponse>(`/api/v1/standings?season_code=${seg}`, 120),
   gamesRecent: (limit = 60) => get<GamesRecentResponse>(`/api/v1/games/recent?limit=${limit}`, 120),
   standings: (season?: number) =>
     get<StandingsResponse>(`/api/v1/season/standings${season ? `?season=${season}` : ""}`),


### PR DESCRIPTION
補足球隊戰績缺口。原本只有自算 w/l/勝率/近10；官方提供更完整。

- migration 020 `team_standings`（含和局、勝差、淘汰指數、對戰各隊H2H、主客場、連勝敗、近十場，分上半季/下半季/全年）
- `cpbl-scrape-standings` + `/api/v1/standings`
- 首頁改用官方戰績 + 上下半季切換（併入團隊 OPS/ERA/WHIP）
- 接進 cpbl-refresh-recent 每次更新 + prod 同步

實測 2026：味全龍 33-0-18 領先、含和局（台鋼28-1-23）、勝差/連勝敗/主客場皆正確。

🤖 Generated with [Claude Code](https://claude.com/claude-code)