### PR TITLE
feat: 前端改版 P1 設計系統 + P2 球員頁旗艦（日間 Navy+白 / Savant 式視覺化）

### DIFF
--- a/src/cpbl/api/main.py
+++ b/src/cpbl/api/main.py
@@ -723,7 +723,17 @@ def player_discipline(
         )
         points = [{"x": float(s), "y": float(h), "sw": sw, "wh": wh}
                   for s, h, sw, wh in cur.fetchall()]
-    return {"player_id": player_id, "role": role, "summary": summary, "points": points}
+        cur.execute(
+            f"""
+            SELECT hit_direction, hit_distance, hit_exit_speed
+            FROM cpbl.pitch_tracking
+            WHERE {col} = %s AND year = %s AND hit_distance IS NOT NULL AND hit_direction IS NOT NULL
+            """,
+            (player_id, season),
+        )
+        spray = [{"dir": float(d), "dist": float(dist), "ev": float(ev) if ev is not None else None}
+                 for d, dist, ev in cur.fetchall()]
+    return {"player_id": player_id, "role": role, "summary": summary, "points": points, "spray": spray}
 
 
 @app.get("/api/v1/standings")

--- a/web/src/app/batters/page.tsx
+++ b/web/src/app/batters/page.tsx
@@ -32,7 +32,7 @@ export default async function BattersPage() {
     <div>
       <header className="mb-5">
         <h1 className="text-2xl font-bold">{season} 球季 · 打者排行</h1>
-        <p className="mt-2 text-sm text-white/50">
+        <p className="mt-2 text-sm text-muted">
           全名單本季打者。點欄位標題排序（再點一次反向），可依球隊篩選。
         </p>
       </header>

--- a/web/src/app/fielding/page.tsx
+++ b/web/src/app/fielding/page.tsx
@@ -23,7 +23,7 @@ export default async function FieldingPage() {
     <div>
       <header className="mb-5">
         <h1 className="text-2xl font-bold">{season} 球季 · 守備數據</h1>
-        <p className="mt-2 text-sm text-white/50">
+        <p className="mt-2 text-sm text-muted">
           逐守備位置統計。點欄位標題排序，可依球隊與守位篩選。守備率 = (刺殺+助殺) ÷ 守備機會。
         </p>
       </header>

--- a/web/src/app/games/[sno]/page.tsx
+++ b/web/src/app/games/[sno]/page.tsx
@@ -19,21 +19,21 @@ function Scoreboard({ sb, game }: { sb: StatRow[]; game: StatRow }) {
     rows.reduce((s, r) => s + (Number(r[key]) || 0), 0);
 
   const row = (label: string, rows: StatRow[], score: number) => (
-    <tr className="border-t border-white/5">
+    <tr className="border-t border-line">
       <td className="whitespace-nowrap px-3 py-2 font-sans font-medium">{label}</td>
       {innings.map((inn) => (
-        <td key={inn} className="px-2.5 py-2 text-center text-white/70">{String(cell(rows, inn))}</td>
+        <td key={inn} className="px-2.5 py-2 text-center text-muted">{String(cell(rows, inn))}</td>
       ))}
-      <td className="px-2.5 py-2 text-center font-semibold text-emerald-400">{score}</td>
-      <td className="px-2.5 py-2 text-center text-white/50">{tot(rows, "hitting_cnt")}</td>
-      <td className="px-2.5 py-2 text-center text-white/50">{tot(rows, "error_cnt")}</td>
+      <td className="px-2.5 py-2 text-center font-semibold text-accent">{score}</td>
+      <td className="px-2.5 py-2 text-center text-muted">{tot(rows, "hitting_cnt")}</td>
+      <td className="px-2.5 py-2 text-center text-muted">{tot(rows, "error_cnt")}</td>
     </tr>
   );
 
   return (
-    <div className="overflow-x-auto rounded-xl border border-white/10">
+    <div className="overflow-x-auto rounded-xl border border-line">
       <table className="w-full text-sm font-mono tabular-nums">
-        <thead className="bg-white/5 text-white/50">
+        <thead className="bg-surface-2 text-muted">
           <tr>
             <th className="px-3 py-2 text-left font-medium">隊伍</th>
             {innings.map((inn) => <th key={inn} className="px-2.5 py-2 font-medium">{inn}</th>)}
@@ -66,8 +66,8 @@ function PlayByPlay({ log }: { log: StatRow[] }) {
   return (
     <div className="space-y-5">
       {groups.map((g, gi) => (
-        <div key={gi} className="rounded-xl border border-white/10 bg-white/[0.02] p-4">
-          <h3 className="mb-2 text-sm font-semibold text-emerald-400">
+        <div key={gi} className="rounded-xl border border-line bg-surface p-4">
+          <h3 className="mb-2 text-sm font-semibold text-accent">
             {g.inning} 局{g.half === "1" ? "上" : "下"}
           </h3>
           <div className="space-y-0.5">
@@ -80,14 +80,14 @@ function PlayByPlay({ log }: { log: StatRow[] }) {
               return (
                 <div key={i}>
                   {newBatter && e.hitter_name && (
-                    <div className="mt-2.5 text-sm font-medium text-white/80">
+                    <div className="mt-2.5 text-sm font-medium text-ink">
                       🏏 {String(e.hitter_name)}
-                      <span className="ml-2 text-xs text-white/40">投：{String(e.pitcher_name ?? "")}</span>
+                      <span className="ml-2 text-xs text-faint">投：{String(e.pitcher_name ?? "")}</span>
                     </div>
                   )}
                   <div
                     className={`pl-5 ${
-                      isScore ? "text-emerald-400" : isPitch ? "text-xs text-white/40" : "text-sm text-white/80"
+                      isScore ? "text-accent" : isPitch ? "text-xs text-faint" : "text-sm text-ink"
                     }`}
                   >
                     {content}
@@ -118,21 +118,21 @@ export default function GameLivePage() {
     detail.gameLive(Number(sno), kind).then((d) => setData(d as Live)).catch(() => setErr(true));
   }, [sno, kind]);
 
-  if (err) return <p className="text-sm text-white/50">載入賽況失敗。</p>;
-  if (!data) return <p className="text-sm text-white/40">載入中…</p>;
-  if (!data.game) return <p className="text-sm text-white/50">查無此場比賽。</p>;
+  if (err) return <p className="text-sm text-muted">載入賽況失敗。</p>;
+  if (!data) return <p className="text-sm text-faint">載入中…</p>;
+  if (!data.game) return <p className="text-sm text-muted">查無此場比賽。</p>;
 
   const g = data.game;
   return (
     <div>
-      <Link href="/games" className="text-xs text-white/40 hover:text-emerald-400">← 返回賽況列表</Link>
+      <Link href="/games" className="text-xs text-faint hover:text-accent">← 返回賽況列表</Link>
       <header className="mb-5 mt-2">
         <h1 className="text-2xl font-bold">
           {String(g.away_team_name)} <span className="font-mono">{n(g.away_score)}</span>
-          <span className="mx-2 text-white/30">@</span>
+          <span className="mx-2 text-faint">@</span>
           {String(g.home_team_name)} <span className="font-mono">{n(g.home_score)}</span>
         </h1>
-        <p className="mt-1 text-sm text-white/50">
+        <p className="mt-1 text-sm text-muted">
           {String(g.game_date ?? "")}　{String(g.venue ?? "")}
         </p>
       </header>
@@ -145,7 +145,7 @@ export default function GameLivePage() {
       <section>
         <h2 className="mb-3 text-lg font-semibold">逐打席賽況</h2>
         {data.livelog.length === 0 ? (
-          <p className="text-sm text-white/40">無逐打席資料。</p>
+          <p className="text-sm text-faint">無逐打席資料。</p>
         ) : (
           <PlayByPlay log={data.livelog} />
         )}

--- a/web/src/app/games/page.tsx
+++ b/web/src/app/games/page.tsx
@@ -18,13 +18,13 @@ export default async function GamesPage() {
     <div>
       <header className="mb-5">
         <h1 className="text-2xl font-bold">{season} 球季 · 賽況</h1>
-        <p className="mt-2 text-sm text-white/50">點任一場看逐局比分與逐打席賽況（play-by-play）。</p>
+        <p className="mt-2 text-sm text-muted">點任一場看逐局比分與逐打席賽況（play-by-play）。</p>
       </header>
 
       <div className="space-y-6">
         {[...byDate.entries()].map(([d, games]) => (
           <section key={d}>
-            <h2 className="mb-2 text-sm font-medium text-white/50">{d}</h2>
+            <h2 className="mb-2 text-sm font-medium text-muted">{d}</h2>
             <div className="grid gap-2 sm:grid-cols-2">
               {games.map((g) => {
                 const awayWin = g.away_score > g.home_score;
@@ -32,21 +32,21 @@ export default async function GamesPage() {
                   <Link
                     key={g.game_sno}
                     href={`/games/${g.game_sno}?kind=${g.kind_code}`}
-                    className="flex items-center justify-between rounded-xl border border-white/10 bg-white/[0.02] px-4 py-3 hover:bg-white/5"
+                    className="flex items-center justify-between rounded-xl border border-line bg-surface px-4 py-3 hover:bg-surface-2"
                   >
                     <div className="space-y-1">
-                      <div className={awayWin ? "font-semibold" : "text-white/70"}>
+                      <div className={awayWin ? "font-semibold" : "text-muted"}>
                         {g.away_team_name}
                       </div>
-                      <div className={!awayWin ? "font-semibold" : "text-white/70"}>
+                      <div className={!awayWin ? "font-semibold" : "text-muted"}>
                         {g.home_team_name}
                       </div>
                     </div>
                     <div className="space-y-1 text-right font-mono tabular-nums">
-                      <div className={awayWin ? "font-semibold text-emerald-400" : "text-white/70"}>
+                      <div className={awayWin ? "font-semibold text-accent" : "text-muted"}>
                         {g.away_score}
                       </div>
-                      <div className={!awayWin ? "font-semibold text-emerald-400" : "text-white/70"}>
+                      <div className={!awayWin ? "font-semibold text-accent" : "text-muted"}>
                         {g.home_score}
                       </div>
                     </div>

--- a/web/src/app/globals.css
+++ b/web/src/app/globals.css
@@ -1,10 +1,32 @@
 @import "tailwindcss";
 
+/* 設計系統 tokens（日間 Navy+白；Tailwind v4 @theme 生成 bg-/text-/border- 工具類） */
+@theme {
+  --color-paper: #f5f7fa;
+  --color-surface: #ffffff;
+  --color-surface-2: #eef2f7;
+  --color-ink: #0a2540;
+  --color-muted: #5b6b7a;
+  --color-faint: #94a3b8;
+  --color-line: #e2e8f0;
+  --color-accent: #d62839;
+  --color-up: #1d6fb8;
+  --color-down: #d62839;
+}
+
 :root {
-  color-scheme: dark;
+  color-scheme: light;
 }
 
 body {
-  background: #0a0a0b;
-  color: #ededed;
+  background: var(--color-paper);
+  color: var(--color-ink);
+}
+
+/* 卡片基底 */
+.card {
+  background: var(--color-surface);
+  border: 1px solid var(--color-line);
+  border-radius: 0.75rem;
+  box-shadow: 0 1px 2px rgb(10 37 64 / 0.04), 0 1px 3px rgb(10 37 64 / 0.06);
 }

--- a/web/src/app/layout.tsx
+++ b/web/src/app/layout.tsx
@@ -4,33 +4,39 @@ import "./globals.css";
 
 export const metadata: Metadata = {
   title: "CPBL 分析 | Ruan Dev",
-  description: "中華職棒本季戰績與單場賽果預測 — 透明變因、可調權重。",
+  description: "中華職棒戰績、進階數據與賽果預測 — TrackMan/Statcast 視覺化。",
 };
+
+const NAV = [
+  { href: "/", label: "戰績" },
+  { href: "/batters", label: "打者" },
+  { href: "/pitchers", label: "投手" },
+  { href: "/fielding", label: "守備" },
+  { href: "/games", label: "賽況" },
+  { href: "/matchups", label: "投打對決" },
+  { href: "/splits", label: "分項" },
+  { href: "/predict", label: "賽果預測" },
+];
 
 export default function RootLayout({ children }: { children: React.ReactNode }) {
   return (
     <html lang="zh-Hant">
       <body className="min-h-screen antialiased">
-        <header className="border-b border-white/10">
-          <div className="mx-auto flex max-w-5xl items-center justify-between px-6 py-4">
-            <Link href="/" className="text-lg font-bold tracking-tight">
-              CPBL <span className="text-emerald-400">分析</span>
+        <header className="sticky top-0 z-40 border-b border-line bg-surface/90 backdrop-blur">
+          <div className="mx-auto flex max-w-6xl items-center justify-between gap-4 px-6 py-3.5">
+            <Link href="/" className="text-lg font-bold tracking-tight text-ink">
+              CPBL <span className="text-accent">分析</span>
             </Link>
-            <nav className="flex gap-4 text-sm text-white/50">
-              <Link href="/" className="hover:text-emerald-400">本季戰績</Link>
-              <Link href="/games" className="hover:text-emerald-400">賽況</Link>
-              <Link href="/batters" className="hover:text-emerald-400">打者</Link>
-              <Link href="/pitchers" className="hover:text-emerald-400">投手</Link>
-              <Link href="/fielding" className="hover:text-emerald-400">守備</Link>
-              <Link href="/matchups" className="hover:text-emerald-400">投打對決</Link>
-              <Link href="/splits" className="hover:text-emerald-400">分項</Link>
-              <Link href="/predict" className="hover:text-emerald-400">賽果預測</Link>
+            <nav className="flex flex-wrap gap-x-4 gap-y-1 text-sm text-muted">
+              {NAV.map((n) => (
+                <Link key={n.href} href={n.href} className="hover:text-ink">{n.label}</Link>
+              ))}
             </nav>
           </div>
         </header>
-        <main className="mx-auto max-w-5xl px-6 py-8">{children}</main>
-        <footer className="mx-auto max-w-5xl px-6 py-10 text-xs text-white/30">
-          資料來源:cpbl-opendata (MIT) + cpbl.com.tw。僅供學習與作品集用途。
+        <main className="mx-auto max-w-6xl px-6 py-8">{children}</main>
+        <footer className="mx-auto max-w-6xl px-6 py-10 text-xs text-faint">
+          資料來源：cpbl-opendata (MIT) + cpbl.com.tw + stats.cpbl.com.tw。僅供學習與作品集用途。
         </footer>
       </body>
     </html>

--- a/web/src/app/matchups/page.tsx
+++ b/web/src/app/matchups/page.tsx
@@ -17,13 +17,13 @@ function Toggle<T extends string>({
   onChange: (v: T) => void;
 }) {
   return (
-    <div className="inline-flex gap-1 rounded-lg bg-white/5 p-1">
+    <div className="inline-flex gap-1 rounded-lg bg-surface-2 p-1">
       {options.map((o) => (
         <button
           key={o.v}
           onClick={() => onChange(o.v)}
           className={`rounded-md px-3 py-1 text-sm transition ${
-            value === o.v ? "bg-emerald-500 text-black" : "text-white/60 hover:text-white"
+            value === o.v ? "bg-ink text-white" : "text-muted hover:text-white"
           }`}
         >
           {o.label}
@@ -75,7 +75,7 @@ export default function MatchupsPage() {
     <div>
       <header className="mb-5">
         <h1 className="text-2xl font-bold">投打對決</h1>
-        <p className="mt-2 text-sm text-white/50">
+        <p className="mt-2 text-sm text-muted">
           選一位球員，列出他生涯對戰過的所有{oppLabel}（同隊不對戰，已自然排除）。
           點欄位排序、依對手球隊篩選、點對手名字看個人頁。
         </p>
@@ -94,7 +94,7 @@ export default function MatchupsPage() {
           <select
             value={pid}
             onChange={(e) => setPid(e.target.value)}
-            className="min-w-52 rounded-lg border border-white/10 bg-white/5 px-3 py-2 text-sm outline-none focus:border-emerald-400"
+            className="min-w-52 rounded-lg border border-line bg-surface-2 px-3 py-2 text-sm outline-none focus:border-ink"
           >
             <option value="">— 選擇{role === "batting" ? "打者" : "投手"} —</option>
             {players.map((p) => (
@@ -115,12 +115,12 @@ export default function MatchupsPage() {
         />
       </div>
 
-      {!pid && <p className="text-sm text-white/40">請先選擇一位{role === "batting" ? "打者" : "投手"}。</p>}
-      {loading && <p className="text-sm text-white/40">查詢中…</p>}
+      {!pid && <p className="text-sm text-faint">請先選擇一位{role === "batting" ? "打者" : "投手"}。</p>}
+      {loading && <p className="text-sm text-faint">查詢中…</p>}
 
       {rows && !loading && (
         rows.length === 0 ? (
-          <p className="rounded-xl border border-white/10 bg-white/[0.02] p-4 text-sm text-white/50">
+          <p className="rounded-xl border border-line bg-surface p-4 text-sm text-muted">
             {pName ?? "該球員"} 在「{KIND_LABEL[kind]}」生涯無對戰{oppLabel}紀錄。
           </p>
         ) : (

--- a/web/src/app/page.tsx
+++ b/web/src/app/page.tsx
@@ -27,7 +27,7 @@ export default async function Home({ searchParams }: { searchParams: Promise<{ s
     <div>
       <header className="mb-5">
         <h1 className="text-2xl font-bold">{season} 球季 · 本季戰績</h1>
-        <p className="mt-2 text-sm text-white/50">官方戰績（含和局/勝差/連勝敗/主客場/近十場）。團隊 OPS/ERA/WHIP 為攻守指標。</p>
+        <p className="mt-2 text-sm text-muted">官方戰績（含和局/勝差/連勝敗/主客場/近十場）。團隊 OPS/ERA/WHIP 為攻守指標。</p>
       </header>
 
       <nav className="mb-4 flex gap-2">
@@ -36,7 +36,7 @@ export default async function Home({ searchParams }: { searchParams: Promise<{ s
             key={s.v}
             href={`/?seg=${s.v}`}
             className={`rounded-full px-3 py-1 text-sm transition ${
-              segCode === s.v ? "bg-emerald-500 text-black" : "bg-white/5 text-white/60 hover:bg-white/10"
+              segCode === s.v ? "bg-ink text-white" : "bg-surface-2 text-muted hover:bg-surface-2"
             }`}
           >
             {s.label}
@@ -45,11 +45,11 @@ export default async function Home({ searchParams }: { searchParams: Promise<{ s
       </nav>
 
       {items.length === 0 ? (
-        <p className="text-sm text-white/40">此區間尚無戰績（下半季可能未開始）。</p>
+        <p className="text-sm text-faint">此區間尚無戰績（下半季可能未開始）。</p>
       ) : (
-        <div className="overflow-x-auto rounded-xl border border-white/10">
+        <div className="overflow-x-auto rounded-xl border border-line">
           <table className="w-full text-sm">
-            <thead className="bg-white/5 text-left text-white/50">
+            <thead className="bg-surface-2 text-left text-muted">
               <tr>
                 {["#", "球隊", "出賽", "勝-和-敗", "勝率", "勝差", "連勝/敗", "主場", "客場", "近十場", "OPS", "ERA", "WHIP"].map(
                   (h) => (
@@ -62,17 +62,17 @@ export default async function Home({ searchParams }: { searchParams: Promise<{ s
               {items.map((t) => {
                 const a = adv.get(t.team_code);
                 return (
-                  <tr key={t.team_code} className="border-t border-white/5 hover:bg-white/5">
-                    <td className="px-2.5 py-2.5 text-white/40">{t.rank}</td>
+                  <tr key={t.team_code} className="border-t border-line hover:bg-surface-2">
+                    <td className="px-2.5 py-2.5 text-faint">{t.rank}</td>
                     <td className="whitespace-nowrap px-2.5 py-2.5 font-sans">{t.team_name}</td>
-                    <td className="px-2.5 py-2.5 text-white/50">{t.g}</td>
+                    <td className="px-2.5 py-2.5 text-muted">{t.g}</td>
                     <td className="px-2.5 py-2.5">{t.w}-{t.t}-{t.l}</td>
-                    <td className="px-2.5 py-2.5 text-emerald-400">{t.win_pct?.toFixed(3) ?? "—"}</td>
-                    <td className="px-2.5 py-2.5 text-white/70">{t.gb === 0 ? "—" : t.gb}</td>
-                    <td className="px-2.5 py-2.5 text-white/60">{t.streak ?? "—"}</td>
-                    <td className="px-2.5 py-2.5 text-white/50">{t.home_record ?? "—"}</td>
-                    <td className="px-2.5 py-2.5 text-white/50">{t.away_record ?? "—"}</td>
-                    <td className="px-2.5 py-2.5 text-white/50">{t.last10 ?? "—"}</td>
+                    <td className="px-2.5 py-2.5 text-accent">{t.win_pct?.toFixed(3) ?? "—"}</td>
+                    <td className="px-2.5 py-2.5 text-muted">{t.gb === 0 ? "—" : t.gb}</td>
+                    <td className="px-2.5 py-2.5 text-muted">{t.streak ?? "—"}</td>
+                    <td className="px-2.5 py-2.5 text-muted">{t.home_record ?? "—"}</td>
+                    <td className="px-2.5 py-2.5 text-muted">{t.away_record ?? "—"}</td>
+                    <td className="px-2.5 py-2.5 text-muted">{t.last10 ?? "—"}</td>
                     <td className="px-2.5 py-2.5">{a?.ops?.toFixed(3) ?? "—"}</td>
                     <td className="px-2.5 py-2.5">{a?.era?.toFixed(2) ?? "—"}</td>
                     <td className="px-2.5 py-2.5">{a?.whip?.toFixed(2) ?? "—"}</td>
@@ -87,10 +87,10 @@ export default async function Home({ searchParams }: { searchParams: Promise<{ s
       {items.length > 0 && (
         <section className="mt-8">
           <h2 className="mb-1 text-lg font-semibold">對戰成績</h2>
-          <p className="mb-3 text-[11px] text-white/30">每列為該隊對各對手的 勝-和-敗（{SEGS.find((s) => s.v === segCode)?.label}）。</p>
-          <div className="overflow-x-auto rounded-xl border border-white/10">
+          <p className="mb-3 text-[11px] text-faint">每列為該隊對各對手的 勝-和-敗（{SEGS.find((s) => s.v === segCode)?.label}）。</p>
+          <div className="overflow-x-auto rounded-xl border border-line">
             <table className="w-full text-sm">
-              <thead className="bg-white/5 text-left text-white/50">
+              <thead className="bg-surface-2 text-left text-muted">
                 <tr>
                   <th className="whitespace-nowrap px-2.5 py-3 font-medium">球隊＼對手</th>
                   {items.map((c) => (
@@ -100,12 +100,12 @@ export default async function Home({ searchParams }: { searchParams: Promise<{ s
               </thead>
               <tbody className="font-mono tabular-nums">
                 {items.map((row) => (
-                  <tr key={row.team_code} className="border-t border-white/5 hover:bg-white/5">
+                  <tr key={row.team_code} className="border-t border-line hover:bg-surface-2">
                     <td className="whitespace-nowrap px-2.5 py-2.5 font-sans">{row.team_name}</td>
                     {items.map((col) => (
-                      <td key={col.team_code} className="px-2.5 py-2.5 text-center text-white/70">
+                      <td key={col.team_code} className="px-2.5 py-2.5 text-center text-muted">
                         {col.team_code === row.team_code ? (
-                          <span className="text-white/15">—</span>
+                          <span className="text-faint">—</span>
                         ) : (
                           row.h2h?.[col.team_code] ?? "—"
                         )}

--- a/web/src/app/pitchers/page.tsx
+++ b/web/src/app/pitchers/page.tsx
@@ -38,7 +38,7 @@ export default async function PitchersPage() {
     <div>
       <header className="mb-5">
         <h1 className="text-2xl font-bold">{season} 球季 · 投手排行</h1>
-        <p className="mt-2 text-sm text-white/50">
+        <p className="mt-2 text-sm text-muted">
           全名單本季投手。點欄位標題排序（再點一次反向），可依球隊篩選。K9 = 三振 × 9 ÷ 局數。
         </p>
       </header>

--- a/web/src/app/players/[id]/page.tsx
+++ b/web/src/app/players/[id]/page.tsx
@@ -3,22 +3,19 @@
 import Link from "next/link";
 import { useParams } from "next/navigation";
 import { useEffect, useMemo, useState } from "react";
-import {
-  CartesianGrid,
-  Line,
-  LineChart,
-  ReferenceArea,
-  ResponsiveContainer,
-  Scatter,
-  ScatterChart,
-  Tooltip,
-  XAxis,
-  YAxis,
-  ZAxis,
-} from "recharts";
+import { CartesianGrid, Line, LineChart, ResponsiveContainer, Tooltip, XAxis, YAxis } from "recharts";
+import { SprayChart } from "@/components/spray-chart";
+import { Card, PercentileBar, StatTile, TeamBadge } from "@/components/ui";
+import { ZoneScatter } from "@/components/zone-scatter";
 import { detail, type PlayerProfile, type StatRow } from "@/lib/client";
+import { codeFromName, teamColor } from "@/lib/teams";
 
 type Role = "batting" | "pitching";
+type Disc = {
+  summary: Record<string, number | null>;
+  points: { x: number; y: number; sw: boolean; wh: boolean }[];
+  spray: { dir: number; dist: number; ev: number | null }[];
+};
 
 const numOf = (v: number | string | null | undefined) =>
   v === null || v === undefined || v === "" ? null : Number(v);
@@ -31,20 +28,29 @@ const ipOf = (r: StatRow) => {
   return c === null ? null : c + (numOf(r.inning_pitched_div3) ?? 0) / 3;
 };
 const eraOf = (r: StatRow) => {
-  const ip = ipOf(r);
-  const er = numOf(r.earned_runs);
+  const ip = ipOf(r), er = numOf(r.earned_runs);
   return ip && ip > 0 && er !== null ? (er * 9) / ip : null;
 };
-const whipOf = (r: StatRow) => {
-  const ip = ipOf(r);
-  const h = numOf(r.hits);
-  const bb = numOf(r.bb);
-  return ip && ip > 0 && h !== null && bb !== null ? (h + bb) / ip : null;
-};
 
-const MONTHS = ["三月", "四月", "五月", "六月", "七月", "八月", "九月", "十月", "十一月"];
+// 官方進階 + PR
+type Adv = { key: string; pr: string; bl: string; pl: string; def: string; kind: "kmh" | "pct" | "rate3" };
+const ADV: Adv[] = [
+  { key: "ev", pr: "ev_pr", bl: "擊球初速", pl: "被擊球初速", def: "平均擊球初速 km/h", kind: "kmh" },
+  { key: "max_ev", pr: "max_ev_pr", bl: "最高初速", pl: "被最高初速", def: "單季最高擊球初速 km/h", kind: "kmh" },
+  { key: "brlp", pr: "brlp_pr", bl: "Barrel%", pl: "被Barrel%", def: "出色擊球率", kind: "pct" },
+  { key: "hardhitp", pr: "hardhitp_pr", bl: "強擊球%", pl: "被強擊球%", def: "強勁擊球占比", kind: "pct" },
+  { key: "woba", pr: "woba_pr", bl: "wOBA", pl: "被wOBA", def: "加權上壘率（官方）", kind: "rate3" },
+  { key: "iso", pr: "iso_pr", bl: "ISO", pl: "被ISO", def: "純長打率", kind: "rate3" },
+  { key: "slg", pr: "slg_pr", bl: "長打率", pl: "被長打率", def: "SLG", kind: "rate3" },
+  { key: "obp", pr: "obp_pr", bl: "上壘率", pl: "被上壘率", def: "OBP", kind: "rate3" },
+  { key: "chasep", pr: "chasep_pr", bl: "追打%", pl: "誘追打%", def: "好球帶外揮棒率", kind: "pct" },
+  { key: "whiffp", pr: "whiffp_pr", bl: "揮空%", pl: "誘揮空%", def: "揮棒落空率", kind: "pct" },
+  { key: "kp", pr: "kp_pr", bl: "K%", pl: "奪三振%", def: "三振率", kind: "pct" },
+  { key: "bbp", pr: "bbp_pr", bl: "BB%", pl: "被保送%", def: "保送率", kind: "pct" },
+];
+const fmtAdv = (v: number, k: Adv["kind"]) =>
+  k === "kmh" ? v.toFixed(1) : k === "pct" ? `${(v * 100).toFixed(1)}%` : v.toFixed(3).replace(/^0\./, ".");
 
-// 逐月趨勢可選的數據
 type Metric = { key: string; label: string; dp: number; get: (r: StatRow) => number | null };
 const BAT_METRICS: Metric[] = [
   { key: "ops", label: "OPS", dp: 3, get: (r) => numOf(r.ops) },
@@ -54,59 +60,22 @@ const BAT_METRICS: Metric[] = [
   { key: "hits", label: "安打", dp: 0, get: (r) => numOf(r.hits) },
   { key: "home_runs", label: "全壘打", dp: 0, get: (r) => numOf(r.home_runs) },
   { key: "rbi", label: "打點", dp: 0, get: (r) => numOf(r.rbi) },
-  { key: "bb", label: "四壞", dp: 0, get: (r) => numOf(r.bb) },
-  { key: "so", label: "三振", dp: 0, get: (r) => numOf(r.so) },
 ];
 const PIT_METRICS: Metric[] = [
   { key: "era", label: "ERA", dp: 2, get: eraOf },
-  { key: "whip", label: "WHIP", dp: 2, get: whipOf },
   { key: "so", label: "三振", dp: 0, get: (r) => numOf(r.so) },
-  { key: "bb", label: "四壞", dp: 0, get: (r) => numOf(r.bb) },
   { key: "hits", label: "被安打", dp: 0, get: (r) => numOf(r.hits) },
-  { key: "ip", label: "局數", dp: 1, get: ipOf },
+  { key: "bb", label: "四壞", dp: 0, get: (r) => numOf(r.bb) },
 ];
+const MONTHS = ["三月", "四月", "五月", "六月", "七月", "八月", "九月", "十月", "十一月"];
+const axis = { tick: { fill: "#5b6b7a", fontSize: 12 }, stroke: "#cbd5e1" };
 
-// 官方進階數據（stats.cpbl）+ 官方 PR。bl=打者標籤、pl=投手標籤；kind 決定數值格式。
-type AdvMetric = { key: string; pr: string; bl: string; pl: string; def: string; kind: "kmh" | "pct" | "rate3" };
-const ADV: AdvMetric[] = [
-  { key: "ev", pr: "ev_pr", bl: "擊球初速", pl: "被擊球初速", def: "平均擊球初速（km/h），擊球品質核心指標", kind: "kmh" },
-  { key: "max_ev", pr: "max_ev_pr", bl: "最高初速", pl: "被最高初速", def: "單季最高擊球初速（km/h）", kind: "kmh" },
-  { key: "brlp", pr: "brlp_pr", bl: "Barrel%", pl: "被Barrel%", def: "出色擊球率：兼具理想初速與仰角的強勁擊球占比", kind: "pct" },
-  { key: "hardhitp", pr: "hardhitp_pr", bl: "強擊球%", pl: "被強擊球%", def: "強勁擊球（高初速）占比", kind: "pct" },
-  { key: "woba", pr: "woba_pr", bl: "wOBA", pl: "被wOBA", def: "加權上壘率（官方計算）", kind: "rate3" },
-  { key: "iso", pr: "iso_pr", bl: "ISO", pl: "被ISO", def: "純長打率＝長打率 − 打擊率", kind: "rate3" },
-  { key: "slg", pr: "slg_pr", bl: "長打率", pl: "被長打率", def: "長打率 SLG", kind: "rate3" },
-  { key: "obp", pr: "obp_pr", bl: "上壘率", pl: "被上壘率", def: "上壘率 OBP", kind: "rate3" },
-  { key: "ba", pr: "ba_pr", bl: "打擊率", pl: "被打擊率", def: "打擊率 AVG", kind: "rate3" },
-  { key: "chasep", pr: "chasep_pr", bl: "追打%", pl: "誘追打%", def: "好球帶外揮棒比率", kind: "pct" },
-  { key: "whiffp", pr: "whiffp_pr", bl: "揮空%", pl: "誘揮空%", def: "揮棒落空比率", kind: "pct" },
-  { key: "kp", pr: "kp_pr", bl: "K%", pl: "奪三振%", def: "三振率", kind: "pct" },
-  { key: "bbp", pr: "bbp_pr", bl: "BB%", pl: "被保送%", def: "保送率", kind: "pct" },
-];
-const fmtAdv = (v: number, kind: AdvMetric["kind"]) =>
-  kind === "kmh" ? v.toFixed(1) : kind === "pct" ? `${(v * 100).toFixed(1)}%` : v.toFixed(3).replace(/^0\./, ".");
-
-const prColor = (v: number) => (v >= 80 ? "#34d399" : v >= 55 ? "#a3e635" : v >= 35 ? "#fbbf24" : "#f87171");
-
-function Toggle<T extends string>({
-  options,
-  value,
-  onChange,
-}: {
-  options: { v: T; label: string }[];
-  value: T;
-  onChange: (v: T) => void;
-}) {
+function Tabs<T extends string>({ opts, v, set }: { opts: { v: T; label: string }[]; v: T; set: (x: T) => void }) {
   return (
-    <div className="inline-flex gap-1 rounded-lg bg-white/5 p-1">
-      {options.map((o) => (
-        <button
-          key={o.v}
-          onClick={() => onChange(o.v)}
-          className={`rounded-md px-3 py-1 text-sm transition ${
-            value === o.v ? "bg-emerald-500 text-black" : "text-white/60 hover:text-white"
-          }`}
-        >
+    <div className="inline-flex gap-1 rounded-lg bg-surface-2 p-1">
+      {opts.map((o) => (
+        <button key={o.v} onClick={() => set(o.v)}
+          className={`rounded-md px-3 py-1 text-sm transition ${v === o.v ? "bg-ink text-white" : "text-muted hover:text-ink"}`}>
           {o.label}
         </button>
       ))}
@@ -114,47 +83,34 @@ function Toggle<T extends string>({
   );
 }
 
-function Card({ label, value, accent }: { label: string; value: string; accent?: boolean }) {
-  return (
-    <div className="rounded-xl border border-white/10 bg-white/[0.02] px-3 py-3 text-center">
-      <div className="text-[11px] text-white/40">{label}</div>
-      <div className={`mt-1 font-mono text-lg tabular-nums ${accent ? "text-emerald-400" : ""}`}>{value}</div>
-    </div>
-  );
-}
-
-const axis = { tick: { fill: "rgba(255,255,255,0.4)", fontSize: 12 }, stroke: "rgba(255,255,255,0.15)" };
-const tooltipStyle = {
-  contentStyle: { background: "#27272a", border: "1px solid rgba(255,255,255,0.1)", borderRadius: 8, fontSize: 12 },
-  labelStyle: { color: "#fff" },
-};
-
 export default function PlayerPage() {
   const { id } = useParams<{ id: string }>();
   const [profile, setProfile] = useState<PlayerProfile | null>(null);
   const [notFound, setNotFound] = useState(false);
   const [role, setRole] = useState<Role>("batting");
   const [scope, setScope] = useState<"season" | "career">("season");
-  const [kinds, setKinds] = useState<string[]>(["A"]); // 生涯可複選賽別
+  const [kinds, setKinds] = useState<string[]>(["A"]);
   const [season, setSeason] = useState<{ batting: StatRow | null; pitching: StatRow | null } | null>(null);
+  const [advanced, setAdvanced] = useState<{ batting: StatRow | null; pitching: StatRow | null } | null>(null);
+  const [disc, setDisc] = useState<Disc | null>(null);
   const [splits, setSplits] = useState<StatRow[] | null>(null);
   const [monthMetric, setMonthMetric] = useState("ops");
-  const [advanced, setAdvanced] = useState<{ batting: StatRow | null; pitching: StatRow | null } | null>(null);
-  const [disc, setDisc] = useState<{ summary: Record<string, number | null>; points: { x: number; y: number; sw: boolean; wh: boolean }[] } | null>(null);
-  const [tip, setTip] = useState<{ text: string; x: number; y: number } | null>(null);
 
   useEffect(() => {
-    detail
-      .profile(id)
-      .then((d) => {
-        if (!d.player) return setNotFound(true);
-        setProfile(d.player);
-        setRole(d.player.is_batter ? "batting" : "pitching");
-      })
-      .catch(() => setNotFound(true));
+    detail.profile(id).then((d) => {
+      if (!d.player) return setNotFound(true);
+      setProfile(d.player);
+      setRole(d.player.is_batter ? "batting" : "pitching");
+    }).catch(() => setNotFound(true));
     detail.season(id).then(setSeason).catch(() => setSeason(null));
     detail.advanced(id).then(setAdvanced).catch(() => setAdvanced(null));
   }, [id]);
+
+  useEffect(() => {
+    setMonthMetric(role === "batting" ? "ops" : "era");
+    setDisc(null);
+    detail.discipline(id, role).then((d) => setDisc(d as Disc)).catch(() => setDisc(null));
+  }, [id, role]);
 
   useEffect(() => {
     if (!profile) return;
@@ -163,304 +119,205 @@ export default function PlayerPage() {
     detail.splits(id, role, year, k).then((d) => setSplits(d.items)).catch(() => setSplits([]));
   }, [id, role, scope, kinds, profile]);
 
-  // 切換打/投時重設逐月指標、抓好球帶紀律
-  useEffect(() => {
-    setMonthMetric(role === "batting" ? "ops" : "era");
-    setDisc(null);
-    detail.discipline(id, role).then(setDisc).catch(() => setDisc(null));
-  }, [id, role]);
-
   const byName = useMemo(() => {
     const m: Record<string, StatRow> = {};
     for (const r of splits ?? []) m[String(r.item_name)] = r;
     return m;
   }, [splits]);
-
   const metrics = role === "batting" ? BAT_METRICS : PIT_METRICS;
   const metric = metrics.find((m) => m.key === monthMetric) ?? metrics[0];
-
   const monthData = useMemo(
     () => MONTHS.filter((mo) => byName[mo]).map((mo) => ({ name: mo.replace("月", ""), v: metric.get(byName[mo]) })),
     [byName, metric],
   );
-
-  // 官方進階 + 官方 PR（stats.cpbl）
-  const prData = useMemo(() => {
+  const prRows = useMemo(() => {
     const a = advanced ? (role === "batting" ? advanced.batting : advanced.pitching) : null;
     if (!a) return [];
     return ADV.map((m) => {
-      const val = numOf(a[m.key]);
-      const pr = numOf(a[m.pr]);
-      return {
-        name: role === "batting" ? m.bl : m.pl,
-        def: m.def,
-        value: val === null ? "—" : fmtAdv(val, m.kind),
-        pr: pr === null ? null : Math.round(pr),
-      };
+      const val = numOf(a[m.key]), pr = numOf(a[m.pr]);
+      return { name: role === "batting" ? m.bl : m.pl, def: m.def,
+        value: val === null ? "—" : fmtAdv(val, m.kind), pr: pr === null ? null : Math.round(pr) };
     }).filter((d): d is { name: string; def: string; value: string; pr: number } => d.pr !== null);
   }, [advanced, role]);
 
-  if (notFound) return <p className="text-sm text-white/50">查無此球員。</p>;
-  if (!profile) return <p className="text-sm text-white/40">載入中…</p>;
+  if (notFound) return <p className="text-sm text-muted">查無此球員。</p>;
+  if (!profile) return <p className="text-sm text-muted">載入中…</p>;
 
   const roles: { v: Role; label: string }[] = [];
   if (profile.is_batter) roles.push({ v: "batting", label: "打擊" });
   if (profile.is_pitcher) roles.push({ v: "pitching", label: "投球" });
-
   const s = season ? (role === "batting" ? season.batting : season.pitching) : null;
+  const tc = codeFromName(profile.team);
 
   return (
     <div>
-      <header className="mb-6">
-        <Link href="/batters" className="text-xs text-white/40 hover:text-emerald-400">← 返回排行</Link>
-        <h1 className="mt-2 text-3xl font-bold">{profile.name}</h1>
-        <p className="mt-1 text-sm text-white/50">
-          {profile.team ?? "—"}
-          {profile.bats && <span className="ml-3">打 {profile.bats}</span>}
-          {profile.throws && <span className="ml-2">投 {profile.throws}</span>}
-        </p>
-      </header>
-
-      {roles.length > 1 && (
-        <div className="mb-5">
-          <Toggle<Role> options={roles} value={role} onChange={setRole} />
+      {/* Hero */}
+      <div className="card mb-6 overflow-hidden">
+        <div className="h-1.5" style={{ background: teamColor(tc) }} />
+        <div className="flex flex-wrap items-end justify-between gap-4 p-5">
+          <div>
+            <h1 className="text-3xl font-bold text-ink">{profile.name}</h1>
+            <p className="mt-1 text-sm text-muted">
+              <TeamBadge code={tc} name={profile.team} />
+              {profile.bats && <span className="ml-3">打 {profile.bats}</span>}
+              {profile.throws && <span className="ml-2">投 {profile.throws}</span>}
+            </p>
+          </div>
+          {s && role === "batting" && (
+            <div className="font-mono text-lg tabular-nums text-ink">
+              {f3(s.avg)}/{f3(s.obp)}/{f3(s.slg)} <span className="text-accent">OPS {f3(s.ops)}</span>
+            </div>
+          )}
+          {s && role === "pitching" && (
+            <div className="font-mono text-lg tabular-nums text-ink">
+              {numOf(s.era)?.toFixed(2) ?? "—"} ERA · {s.w ?? 0}-{s.l ?? 0} · {numOf(s.ip)?.toFixed(1) ?? "—"} 局
+            </div>
+          )}
         </div>
-      )}
-
-      {/* 本季成績卡 */}
-      <section className="mb-8">
-        <h2 className="mb-3 text-lg font-semibold">本季成績</h2>
-        {!s ? (
-          <p className="text-sm text-white/40">本季無{role === "batting" ? "打擊" : "投球"}成績。</p>
-        ) : (
-          <div className="grid grid-cols-3 gap-2 sm:grid-cols-5">
-            {role === "batting"
-              ? [
-                  ["打擊率", f3(s.avg), true],
-                  ["上壘率", f3(s.obp)],
-                  ["長打率", f3(s.slg)],
-                  ["OPS", f3(s.ops), true],
-                  ["全壘打", String(s.hr ?? "—")],
-                  ["打點", String(s.rbi ?? "—")],
-                  ["安打", String(s.h ?? "—")],
-                  ["盜壘", String(s.sb ?? "—")],
-                  ["打席", String(s.pa ?? "—")],
-                  ["出賽", String(s.g ?? "—")],
-                ].map(([l, v, a]) => <Card key={l as string} label={l as string} value={v as string} accent={a as boolean} />)
-              : [
-                  ["防禦率", numOf(s.era)?.toFixed(2) ?? "—", true],
-                  ["WHIP", numOf(s.whip)?.toFixed(2) ?? "—"],
-                  ["勝-敗", `${s.w ?? 0}-${s.l ?? 0}`],
-                  ["局數", numOf(s.ip)?.toFixed(1) ?? "—"],
-                  ["三振", String(s.so ?? "—"), true],
-                  ["K9", numOf(s.k9)?.toFixed(2) ?? "—"],
-                  ["救援", String(s.sv ?? "—")],
-                  ["中繼", String(s.hld ?? "—")],
-                  ["自責", String(s.er ?? "—")],
-                  ["出賽", String(s.g ?? "—")],
-                ].map(([l, v, a]) => <Card key={l as string} label={l as string} value={v as string} accent={a as boolean} />)}
-          </div>
-        )}
-      </section>
-
-      {/* 分項範圍切換 */}
-      <div className="mb-4 flex flex-wrap items-center gap-3">
-        <Toggle
-          options={[
-            { v: "season", label: "本季" },
-            { v: "career", label: "生涯" },
-          ]}
-          value={scope}
-          onChange={setScope}
-        />
-        {scope === "career" && (
-          <div className="inline-flex flex-wrap gap-2">
-            {([["A", "例行賽"], ["C", "總冠軍"], ["E", "季後賽"]] as const).map(([k, label]) => {
-              const on = kinds.includes(k);
-              return (
-                <button
-                  key={k}
-                  onClick={() =>
-                    setKinds(on ? (kinds.length > 1 ? kinds.filter((x) => x !== k) : kinds) : [...kinds, k])
-                  }
-                  className={`rounded-full px-3 py-1 text-sm transition ${
-                    on ? "bg-emerald-500 text-black" : "bg-white/5 text-white/60 hover:bg-white/10"
-                  }`}
-                >
-                  {label}
-                </button>
-              );
-            })}
-            <span className="self-center text-xs text-white/30">可複選</span>
-          </div>
-        )}
       </div>
 
-      {/* 選手分析圖表 */}
+      {roles.length > 1 && <div className="mb-5"><Tabs opts={roles} v={role} set={setRole} /></div>}
+
+      {/* 本季成績卡 */}
+      {s && (
+        <section className="mb-8">
+          <h2 className="mb-3 text-lg font-semibold text-ink">本季成績</h2>
+          <div className="grid grid-cols-3 gap-2 sm:grid-cols-5">
+            {(role === "batting"
+              ? [["打擊率", f3(s.avg), true], ["上壘率", f3(s.obp), false], ["長打率", f3(s.slg), false],
+                 ["OPS", f3(s.ops), true], ["全壘打", String(s.hr ?? "—"), false], ["打點", String(s.rbi ?? "—"), false],
+                 ["安打", String(s.h ?? "—"), false], ["盜壘", String(s.sb ?? "—"), false], ["打席", String(s.pa ?? "—"), false],
+                 ["出賽", String(s.g ?? "—"), false]]
+              : [["防禦率", numOf(s.era)?.toFixed(2) ?? "—", true], ["WHIP", numOf(s.whip)?.toFixed(2) ?? "—", false],
+                 ["勝-敗", `${s.w ?? 0}-${s.l ?? 0}`, false], ["局數", numOf(s.ip)?.toFixed(1) ?? "—", false],
+                 ["三振", String(s.so ?? "—"), true], ["K9", numOf(s.k9)?.toFixed(2) ?? "—", false],
+                 ["救援", String(s.sv ?? "—"), false], ["中繼", String(s.hld ?? "—"), false],
+                 ["自責", String(s.er ?? "—"), false], ["出賽", String(s.g ?? "—"), false]]
+            ).map(([l, v, a]) => <StatTile key={l as string} label={l as string} value={v as string} accent={a as boolean} />)}
+          </div>
+        </section>
+      )}
+
+      {/* 百分位 */}
+      <section className="mb-8">
+        <h2 className="mb-3 text-lg font-semibold text-ink">官方進階數據 · 百分位 PR</h2>
+        <Card>
+          {prRows.length === 0 ? (
+            <p className="py-8 text-center text-sm text-faint">{advanced === null ? "載入中…" : "無官方進階資料"}</p>
+          ) : (
+            <div className="space-y-1.5">
+              {prRows.map((d) => <PercentileBar key={d.name} name={d.name} value={d.value} pr={d.pr} def={d.def} />)}
+            </div>
+          )}
+          <p className="mt-3 text-[11px] text-faint">
+            來源 stats.cpbl 官方 TrackMan；色條＝官方 PR（藍低→紅高）。{role === "batting" ? "打者進攻數值" : "投手被打數值"}。
+          </p>
+        </Card>
+      </section>
+
+      {/* 擊球落點 + 進壘點 */}
       <section className="mb-8 grid gap-6 lg:grid-cols-2">
-        <div className="rounded-xl border border-white/10 bg-white/[0.02] p-4">
+        <Card>
+          <h3 className="mb-2 text-sm font-medium text-muted">擊球落點（點＝擊球初速 藍低→紅高，{disc?.spray.length ?? 0} 球）</h3>
+          {disc && disc.spray.length > 0 ? <SprayChart points={disc.spray} />
+            : <p className="py-12 text-center text-sm text-faint">{disc === null ? "載入中…" : "無擊球追蹤資料"}</p>}
+        </Card>
+        <Card>
+          <h3 className="mb-2 text-sm font-medium text-muted">進壘點（紅＝揮空、藍＝揮棒、灰＝未揮棒，{disc?.points.length ?? 0} 球）</h3>
+          {disc && disc.points.length > 0 ? <ZoneScatter points={disc.points} />
+            : <p className="py-12 text-center text-sm text-faint">{disc === null ? "載入中…" : "無逐球資料"}</p>}
+          {disc && disc.summary.swing_pct != null && (
+            <div className="mt-2 flex flex-wrap gap-x-4 gap-y-1 text-xs text-muted">
+              <span>揮棒 {disc.summary.swing_pct}%</span><span>揮空 {disc.summary.whiff_pct}%</span>
+              <span>接觸 {disc.summary.contact_pct}%</span><span>CSW {disc.summary.csw_pct}%</span>
+              <span>追打 {disc.summary.chase_pct}%（近似）</span>
+            </div>
+          )}
+        </Card>
+      </section>
+
+      {/* 範圍切換 + 逐月趨勢 */}
+      <section className="mb-8">
+        <div className="mb-3 flex flex-wrap items-center gap-3">
+          <Tabs opts={[{ v: "season", label: "本季" }, { v: "career", label: "生涯" }]} v={scope} set={setScope} />
+          {scope === "career" && (
+            <div className="inline-flex flex-wrap gap-2">
+              {([["A", "例行賽"], ["C", "總冠軍"], ["E", "季後賽"]] as const).map(([k, label]) => {
+                const on = kinds.includes(k);
+                return (
+                  <button key={k} onClick={() => setKinds(on ? (kinds.length > 1 ? kinds.filter((x) => x !== k) : kinds) : [...kinds, k])}
+                    className={`rounded-full px-3 py-1 text-sm transition ${on ? "bg-accent text-white" : "bg-surface-2 text-muted hover:text-ink"}`}>
+                    {label}
+                  </button>
+                );
+              })}
+            </div>
+          )}
+        </div>
+        <Card>
           <div className="mb-3 flex items-center justify-between gap-3">
-            <h3 className="text-sm font-medium text-white/70">逐月趨勢</h3>
-            <select
-              value={monthMetric}
-              onChange={(e) => setMonthMetric(e.target.value)}
-              className="rounded-md border border-white/10 bg-white/5 px-2 py-1 text-xs outline-none focus:border-emerald-400"
-            >
-              {metrics.map((m) => (
-                <option key={m.key} value={m.key}>
-                  {m.label}
-                </option>
-              ))}
+            <h3 className="text-sm font-medium text-muted">逐月趨勢</h3>
+            <select value={monthMetric} onChange={(e) => setMonthMetric(e.target.value)}
+              className="rounded-md border border-line bg-surface px-2 py-1 text-xs text-ink outline-none focus:border-ink">
+              {metrics.map((m) => <option key={m.key} value={m.key}>{m.label}</option>)}
             </select>
           </div>
-          {monthData.length === 0 ? (
-            <p className="py-10 text-center text-sm text-white/30">無資料</p>
-          ) : (
+          {monthData.length === 0 ? <p className="py-8 text-center text-sm text-faint">無資料</p> : (
             <ResponsiveContainer width="100%" height={220}>
               <LineChart data={monthData} margin={{ top: 5, right: 10, left: -10, bottom: 0 }}>
-                <CartesianGrid stroke="rgba(255,255,255,0.08)" />
+                <CartesianGrid stroke="#eef2f7" />
                 <XAxis dataKey="name" {...axis} />
                 <YAxis {...axis} domain={["auto", "auto"]} />
-                <Tooltip {...tooltipStyle} formatter={(v: number) => v?.toFixed(metric.dp)} />
-                <Line type="monotone" dataKey="v" name={metric.label} stroke="#34d399" strokeWidth={2} dot={{ r: 3 }} />
+                <Tooltip contentStyle={{ background: "#fff", border: "1px solid #e2e8f0", borderRadius: 8, fontSize: 12 }}
+                  formatter={(v: number) => v?.toFixed(metric.dp)} />
+                <Line type="monotone" dataKey="v" name={metric.label} stroke="#0a2540" strokeWidth={2} dot={{ r: 3, fill: "#d62839" }} />
               </LineChart>
             </ResponsiveContainer>
           )}
-        </div>
-
-        <div className="rounded-xl border border-white/10 bg-white/[0.02] p-4">
-          <h3 className="mb-3 text-sm font-medium text-white/70">官方進階數據 · 百分位 PR</h3>
-          {prData.length === 0 ? (
-            <p className="py-10 text-center text-sm text-white/30">
-              {advanced === null ? "載入中…" : "無官方進階資料"}
-            </p>
-          ) : (
-            <div className="space-y-1.5">
-              {prData.map((d) => (
-                <div key={d.name} className="flex items-center gap-2.5 text-sm">
-                  <span
-                    onMouseEnter={(e) => setTip({ text: d.def, x: e.clientX, y: e.clientY })}
-                    onMouseMove={(e) => setTip({ text: d.def, x: e.clientX, y: e.clientY })}
-                    onMouseLeave={() => setTip(null)}
-                    className="w-16 shrink-0 cursor-help text-white/70 underline decoration-white/25 decoration-dotted underline-offset-4"
-                  >
-                    {d.name}
-                  </span>
-                  <div className="relative h-4 flex-1 overflow-hidden rounded bg-white/5">
-                    <div className="h-full rounded" style={{ width: `${d.pr}%`, background: prColor(d.pr) }} />
-                  </div>
-                  <span className="w-12 shrink-0 text-right font-mono tabular-nums">{d.value}</span>
-                  <span className="w-9 shrink-0 text-right font-mono text-xs text-white/40">{d.pr}</span>
-                </div>
-              ))}
-            </div>
-          )}
-          <p className="mt-3 text-[11px] text-white/30">
-            來源 stats.cpbl.com.tw 官方 TrackMan/Statcast 數據；數值右側為實際成績，色條＝官方 PR
-            （0–100，已定向為「越高＝表現越好」）。{role === "batting" ? "打者為進攻數值" : "投手為被打數值"}。滑過數據名看定義。
-          </p>
-        </div>
+        </Card>
       </section>
 
-      {tip && (
-        <div
-          className="pointer-events-none fixed z-50 max-w-xs rounded-md border border-white/10 bg-zinc-800 px-2.5 py-1.5 text-xs leading-relaxed text-white shadow-xl"
-          style={{ left: tip.x + 14, top: tip.y + 16 }}
-        >
-          {tip.text}
-        </div>
-      )}
-
-      {/* 好球帶紀律 */}
-      <section className="mb-8">
-        <h2 className="mb-1 text-lg font-semibold">好球帶紀律 · {role === "batting" ? "打者" : "投手誘導"}</h2>
-        <p className="mb-3 text-[11px] text-white/30">
-          依逐球進壘點計算（僅含有 TrackMan 的場次）；好球帶為近似框，追打/好球帶% 僅供參考，
-          權威 chase%/whiff% 見上方官方數據。
-        </p>
-        {!disc ? (
-          <p className="text-sm text-white/40">載入中…</p>
-        ) : disc.points.length === 0 ? (
-          <p className="text-sm text-white/40">無逐球資料。</p>
-        ) : (
-          <div className="grid gap-6 lg:grid-cols-2">
-            <div className="grid grid-cols-3 gap-2 self-start">
-              {([["揮棒%", "swing_pct"], ["接觸%", "contact_pct"], ["揮空%", "whiff_pct"],
-                 ["CSW%", "csw_pct"], ["好球帶%", "zone_pct"], ["追打%", "chase_pct"]] as const).map(([l, k]) => (
-                <Card key={l} label={l} value={disc.summary[k] == null ? "—" : `${disc.summary[k]}%`} />
-              ))}
-            </div>
-            <div className="rounded-xl border border-white/10 bg-white/[0.02] p-4">
-              <h3 className="mb-2 text-sm font-medium text-white/70">進壘點散布（{disc.points.length} 球）</h3>
-              <ResponsiveContainer width="100%" height={300}>
-                <ScatterChart margin={{ top: 5, right: 10, left: -10, bottom: 0 }}>
-                  <CartesianGrid stroke="rgba(255,255,255,0.06)" />
-                  <XAxis type="number" dataKey="x" domain={[-0.8, 0.8]} {...axis} tickFormatter={() => ""} />
-                  <YAxis type="number" dataKey="y" domain={[-0.2, 1.6]} {...axis} tickFormatter={() => ""} />
-                  <ZAxis range={[18, 18]} />
-                  <ReferenceArea x1={-0.21} x2={0.21} y1={0.5} y2={1.0}
-                    stroke="rgba(255,255,255,0.45)" fill="rgba(255,255,255,0.04)" />
-                  <Tooltip {...tooltipStyle} cursor={{ strokeDasharray: "3 3" }} />
-                  <Scatter name="未揮棒" data={disc.points.filter((p) => !p.sw)} fill="rgba(255,255,255,0.25)" />
-                  <Scatter name="揮棒" data={disc.points.filter((p) => p.sw && !p.wh)} fill="#34d399" />
-                  <Scatter name="揮空" data={disc.points.filter((p) => p.wh)} fill="#f87171" />
-                </ScatterChart>
-              </ResponsiveContainer>
-              <p className="mt-1 text-[11px] text-white/30">綠＝揮棒（擊中/界外）、紅＝揮空、灰＝未揮棒；白框＝好球帶(近似)。</p>
-            </div>
-          </div>
-        )}
-      </section>
-
-      {/* 分項明細表 */}
-      <section>
-        <h2 className="mb-3 text-lg font-semibold">分項明細</h2>
-        {!splits ? (
-          <p className="text-sm text-white/40">載入中…</p>
-        ) : splits.length === 0 ? (
-          <p className="text-sm text-white/40">此範圍無分項資料。</p>
-        ) : (
-          <div className="overflow-x-auto rounded-xl border border-white/10">
+      {/* 分項明細 */}
+      <section className="mb-6">
+        <h2 className="mb-3 text-lg font-semibold text-ink">分項明細</h2>
+        {!splits ? <p className="text-sm text-muted">載入中…</p>
+          : splits.length === 0 ? <p className="text-sm text-muted">此範圍無分項資料。</p> : (
+          <div className="overflow-x-auto rounded-xl border border-line bg-surface">
             <table className="w-full text-sm">
-              <thead className="bg-white/5 text-left text-white/50">
+              <thead className="bg-surface-2 text-left text-muted">
                 <tr>
                   {(role === "batting"
-                    ? ["分項", "打席", "打數", "安打", "全壘打", "打點", "四壞", "三振", "打擊率", "上壘率", "長打率", "OPS"]
-                    : ["分項", "局數", "面對", "被安", "被轟", "四壞", "三振", "失分", "自責", "ERA"]
-                  ).map((h) => (
-                    <th key={h} className="whitespace-nowrap px-2.5 py-2.5 font-medium">{h}</th>
-                  ))}
+                    ? ["分項", "打席", "打數", "安打", "全壘打", "打點", "四壞", "三振", "打擊率", "OPS"]
+                    : ["分項", "局數", "面對", "被安", "被轟", "四壞", "三振", "自責", "ERA"]
+                  ).map((h) => <th key={h} className="whitespace-nowrap px-2.5 py-2.5 font-medium">{h}</th>)}
                 </tr>
               </thead>
               <tbody className="font-mono tabular-nums">
                 {splits.map((r, i) => (
-                  <tr key={i} className="border-t border-white/5 hover:bg-white/5">
-                    <td className="whitespace-nowrap px-2.5 py-2 font-sans text-white/80">{String(r.item_name)}</td>
+                  <tr key={i} className="border-t border-line hover:bg-surface-2">
+                    <td className="whitespace-nowrap px-2.5 py-2 font-sans text-ink">{String(r.item_name)}</td>
                     {role === "batting" ? (
                       <>
                         <td className="px-2.5 py-2">{String(r.plate_appearances ?? "—")}</td>
-                        <td className="px-2.5 py-2 text-white/50">{String(r.at_bats ?? "—")}</td>
+                        <td className="px-2.5 py-2 text-muted">{String(r.at_bats ?? "—")}</td>
                         <td className="px-2.5 py-2">{String(r.hits ?? "—")}</td>
                         <td className="px-2.5 py-2">{String(r.home_runs ?? "—")}</td>
                         <td className="px-2.5 py-2">{String(r.rbi ?? "—")}</td>
-                        <td className="px-2.5 py-2 text-white/50">{String(r.bb ?? "—")}</td>
-                        <td className="px-2.5 py-2 text-white/50">{String(r.so ?? "—")}</td>
+                        <td className="px-2.5 py-2 text-muted">{String(r.bb ?? "—")}</td>
+                        <td className="px-2.5 py-2 text-muted">{String(r.so ?? "—")}</td>
                         <td className="px-2.5 py-2">{f3(r.avg)}</td>
-                        <td className="px-2.5 py-2">{f3(r.obp)}</td>
-                        <td className="px-2.5 py-2">{f3(r.slg)}</td>
-                        <td className="px-2.5 py-2 text-emerald-400">{f3(r.ops)}</td>
+                        <td className="px-2.5 py-2 text-accent">{f3(r.ops)}</td>
                       </>
                     ) : (
                       <>
                         <td className="px-2.5 py-2">{ipOf(r)?.toFixed(1) ?? "—"}</td>
-                        <td className="px-2.5 py-2 text-white/50">{String(r.plate_appearances ?? "—")}</td>
-                        <td className="px-2.5 py-2 text-white/50">{String(r.hits ?? "—")}</td>
-                        <td className="px-2.5 py-2 text-white/50">{String(r.home_runs ?? "—")}</td>
-                        <td className="px-2.5 py-2 text-white/50">{String(r.bb ?? "—")}</td>
+                        <td className="px-2.5 py-2 text-muted">{String(r.plate_appearances ?? "—")}</td>
+                        <td className="px-2.5 py-2 text-muted">{String(r.hits ?? "—")}</td>
+                        <td className="px-2.5 py-2 text-muted">{String(r.home_runs ?? "—")}</td>
+                        <td className="px-2.5 py-2 text-muted">{String(r.bb ?? "—")}</td>
                         <td className="px-2.5 py-2">{String(r.so ?? "—")}</td>
-                        <td className="px-2.5 py-2 text-white/50">{String(r.runs ?? "—")}</td>
-                        <td className="px-2.5 py-2 text-rose-400/80">{String(r.earned_runs ?? "—")}</td>
-                        <td className="px-2.5 py-2 text-emerald-400">{eraOf(r)?.toFixed(2) ?? "—"}</td>
+                        <td className="px-2.5 py-2 text-accent">{String(r.earned_runs ?? "—")}</td>
+                        <td className="px-2.5 py-2 text-accent">{eraOf(r)?.toFixed(2) ?? "—"}</td>
                       </>
                     )}
                   </tr>
@@ -471,10 +328,9 @@ export default function PlayerPage() {
         )}
       </section>
 
-      <div className="mt-8">
-        <Link href="/matchups" className="text-sm text-emerald-400 hover:underline">
-          查看投打對決 →
-        </Link>
+      <div className="flex gap-4 text-sm">
+        <Link href="/matchups" className="text-accent hover:underline">投打對決 →</Link>
+        <Link href="/batters" className="text-muted hover:text-ink">← 返回排行</Link>
       </div>
     </div>
   );

--- a/web/src/app/predict/page.tsx
+++ b/web/src/app/predict/page.tsx
@@ -84,11 +84,11 @@ export default function PredictPage() {
     <div>
       <header className="mb-5">
         <h1 className="text-2xl font-bold">賽果預測 · 單場對戰</h1>
-        <p className="mt-2 text-sm text-white/50">
+        <p className="mt-2 text-sm text-muted">
           勾選你在意的變因,把雙方真實數字攤開比較;勝率用歷史學出的「預設權重」起算,
           你也能拖滑桿手動微調(拖大 = 更決斷)。
           {model && (
-            <span className="ml-1 text-white/35">
+            <span className="ml-1 text-muted">
               模型參考準確率 {(model.accuracy * 100).toFixed(1)}%(基準{" "}
               {(model.baseline * 100).toFixed(1)}%)。
             </span>
@@ -97,13 +97,13 @@ export default function PredictPage() {
       </header>
 
       {/* 模式切換 */}
-      <div className="mb-4 inline-flex rounded-lg border border-white/10 p-1 text-sm">
+      <div className="mb-4 inline-flex rounded-lg border border-line p-1 text-sm">
         {(["upcoming", "simulate"] as Mode[]).map((mo) => (
           <button
             key={mo}
             onClick={() => setMode(mo)}
             className={`rounded-md px-3 py-1.5 transition ${
-              mode === mo ? "bg-emerald-500 text-black" : "text-white/50 hover:text-white"
+              mode === mo ? "bg-ink text-white" : "text-muted hover:text-white"
             }`}
           >
             {mo === "upcoming" ? "今日/近期賽事" : "任選兩隊模擬"}
@@ -121,8 +121,8 @@ export default function PredictPage() {
                 onClick={() => toggle(f.key)}
                 className={`rounded-lg border px-3 py-1.5 text-sm transition ${
                   on
-                    ? "border-emerald-500 bg-emerald-500/15 text-emerald-300"
-                    : "border-white/10 bg-white/5 text-white/40 hover:border-white/20"
+                    ? "border-accent bg-ink/15 text-accent"
+                    : "border-line bg-surface-2 text-faint hover:border-line"
                 }`}
               >
                 {on ? "✓ " : ""}
@@ -131,7 +131,7 @@ export default function PredictPage() {
               {f.desc && (
                 <span
                   role="tooltip"
-                  className="pointer-events-none absolute left-1/2 top-full z-10 mt-2 w-60 -translate-x-1/2 rounded-lg border border-white/10 bg-neutral-900 px-3 py-2 text-xs leading-relaxed text-white/70 opacity-0 shadow-xl transition-opacity duration-150 group-hover:opacity-100"
+                  className="pointer-events-none absolute left-1/2 top-full z-10 mt-2 w-60 -translate-x-1/2 rounded-lg border border-line bg-neutral-900 px-3 py-2 text-xs leading-relaxed text-muted opacity-0 shadow-xl transition-opacity duration-150 group-hover:opacity-100"
                 >
                   {f.desc}
                 </span>
@@ -143,12 +143,12 @@ export default function PredictPage() {
 
       {/* 權重滑桿 */}
       {selected.length > 0 && (
-        <section className="mb-6 rounded-xl border border-white/10 p-4">
+        <section className="mb-6 rounded-xl border border-line p-4">
           <div className="mb-3 flex items-center justify-between">
-            <h2 className="text-sm font-medium text-white/50">變因權重(影響力)</h2>
+            <h2 className="text-sm font-medium text-muted">變因權重(影響力)</h2>
             <button
               onClick={() => model && setWeights(model.weights)}
-              className="text-xs text-white/40 hover:text-emerald-400"
+              className="text-xs text-faint hover:text-accent"
             >
               重設為預設
             </button>
@@ -156,7 +156,7 @@ export default function PredictPage() {
           <div className="grid gap-3 sm:grid-cols-2">
             {selected.map((k) => (
               <label key={k} className="flex items-center gap-3 text-sm">
-                <span className="w-24 shrink-0 text-white/60">{label[k] ?? k}</span>
+                <span className="w-24 shrink-0 text-muted">{label[k] ?? k}</span>
                 <input
                   type="range"
                   min={0}
@@ -166,9 +166,9 @@ export default function PredictPage() {
                   onChange={(e) =>
                     setWeights((w) => ({ ...w, [k]: parseFloat(e.target.value) }))
                   }
-                  className="flex-1 accent-emerald-500"
+                  className="flex-1 accent-accent"
                 />
-                <span className="w-10 text-right font-mono text-xs text-white/40">
+                <span className="w-10 text-right font-mono text-xs text-faint">
                   {(weights[k] ?? 0).toFixed(2)}
                 </span>
               </label>
@@ -181,17 +181,17 @@ export default function PredictPage() {
       {mode === "simulate" && (
         <section className="mb-4 flex flex-wrap items-center gap-3 text-sm">
           <TeamSelect label="客隊" teams={teams} value={away} onChange={setAway} />
-          <span className="text-white/30">@</span>
+          <span className="text-faint">@</span>
           <TeamSelect label="主隊" teams={teams} value={home} onChange={setHome} />
         </section>
       )}
 
       {/* 卡片 */}
       <section className="space-y-2">
-        {loading && <p className="text-sm text-white/30">計算中…</p>}
+        {loading && <p className="text-sm text-faint">計算中…</p>}
         {!loading && mode === "upcoming" &&
           (items.length === 0 ? (
-            <p className="text-sm text-white/30">目前無未開打場次(休賽期或賽季結束)。</p>
+            <p className="text-sm text-faint">目前無未開打場次(休賽期或賽季結束)。</p>
           ) : (
             items.map((m, i) => <MatchupCard key={i} m={m} weights={weights} />)
           ))}
@@ -214,11 +214,11 @@ function TeamSelect({
 }) {
   return (
     <label className="flex items-center gap-2">
-      <span className="text-white/40">{label}</span>
+      <span className="text-faint">{label}</span>
       <select
         value={value}
         onChange={(e) => onChange(e.target.value)}
-        className="rounded-lg border border-white/10 bg-white/5 px-3 py-1.5 text-white"
+        className="rounded-lg border border-line bg-surface-2 px-3 py-1.5 text-white"
       >
         {teams.map((t) => (
           <option key={t.code} value={t.code} className="bg-neutral-900">

--- a/web/src/app/splits/page.tsx
+++ b/web/src/app/splits/page.tsx
@@ -51,13 +51,13 @@ function Toggle<T extends string>({
   onChange: (v: T) => void;
 }) {
   return (
-    <div className="inline-flex gap-1 rounded-lg bg-white/5 p-1">
+    <div className="inline-flex gap-1 rounded-lg bg-surface-2 p-1">
       {options.map((o) => (
         <button
           key={o.v}
           onClick={() => onChange(o.v)}
           className={`rounded-md px-3 py-1 text-sm transition ${
-            value === o.v ? "bg-emerald-500 text-black" : "text-white/60 hover:text-white"
+            value === o.v ? "bg-ink text-white" : "text-muted hover:text-white"
           }`}
         >
           {o.label}
@@ -120,7 +120,7 @@ export default function SplitsPage() {
     <div>
       <header className="mb-5">
         <h1 className="text-2xl font-bold">分項成績</h1>
-        <p className="mt-2 text-sm text-white/50">
+        <p className="mt-2 text-sm text-muted">
           主客場 / 左右投打 / 本土外籍 / 壘上跑者 / 出局數 / 局數 / 比分 / 月份 / 球場 / 棒次。
           本季僅一軍例行賽；生涯累計含季後賽。資料來源 cpbl.com.tw。
         </p>
@@ -139,7 +139,7 @@ export default function SplitsPage() {
           <select
             value={pid}
             onChange={(e) => setPid(e.target.value)}
-            className="rounded-lg border border-white/10 bg-white/5 px-3 py-2 text-sm outline-none focus:border-emerald-400"
+            className="rounded-lg border border-line bg-surface-2 px-3 py-2 text-sm outline-none focus:border-ink"
           >
             <option value="">— 選擇{role === "batting" ? "打者" : "投手"} —</option>
             {players.map((p) => (
@@ -170,24 +170,24 @@ export default function SplitsPage() {
         )}
       </div>
 
-      {loading && <p className="text-sm text-white/40">查詢中…</p>}
+      {loading && <p className="text-sm text-faint">查詢中…</p>}
 
       {rows && !loading && (
         rows.length === 0 ? (
-          <p className="rounded-xl border border-white/10 bg-white/[0.02] p-4 text-sm text-white/50">
+          <p className="rounded-xl border border-line bg-surface p-4 text-sm text-muted">
             {pName ?? "該選手"} 在此範圍無分項資料。
           </p>
         ) : (
-          <div className="overflow-x-auto rounded-xl border border-white/10">
+          <div className="overflow-x-auto rounded-xl border border-line">
             <table className="w-full text-sm">
-              <thead className="bg-white/5 text-left text-white/50">
+              <thead className="bg-surface-2 text-left text-muted">
                 <tr>
                   <th className="whitespace-nowrap px-2.5 py-3 font-medium">分項</th>
                   {cols.map(([h, tip]) => (
                     <th
                       key={h}
                       title={tip}
-                      className="cursor-help whitespace-nowrap px-2.5 py-3 font-medium underline decoration-white/20 decoration-dotted underline-offset-4"
+                      className="cursor-help whitespace-nowrap px-2.5 py-3 font-medium underline decoration-line decoration-dotted underline-offset-4"
                     >
                       {h}
                     </th>
@@ -196,8 +196,8 @@ export default function SplitsPage() {
               </thead>
               <tbody className="font-mono tabular-nums">
                 {rows.map((r, i) => (
-                  <tr key={i} className="border-t border-white/5 hover:bg-white/5">
-                    <td className="whitespace-nowrap px-2.5 py-2.5 font-sans text-white/80">
+                  <tr key={i} className="border-t border-line hover:bg-surface-2">
+                    <td className="whitespace-nowrap px-2.5 py-2.5 font-sans text-ink">
                       {n(r.item_name)}
                     </td>
                     {cols.map(([h, , get]) => (

--- a/web/src/components/leaderboard.tsx
+++ b/web/src/components/leaderboard.tsx
@@ -31,7 +31,7 @@ const fmtVal = (v: number | string | null, fmt?: Fmt): string => {
 };
 
 const toneCls = (tone?: Tone): string =>
-  tone === "accent" ? "text-emerald-400" : tone === "warn" ? "text-rose-400/80" : tone === "dim" ? "text-white/50" : "";
+  tone === "accent" ? "text-accent" : tone === "warn" ? "text-accent" : tone === "dim" ? "text-muted" : "";
 
 function cmp(a: number | string | null, b: number | string | null, dir: 1 | -1): number {
   const an = a === null || a === undefined || a === "";
@@ -93,11 +93,11 @@ export default function Leaderboard({
         <div className="mb-4 flex flex-wrap gap-3">
           {filters.map((f) => (
             <label key={f.key} className="flex items-center gap-2 text-sm">
-              <span className="text-white/50">{f.label}</span>
+              <span className="text-muted">{f.label}</span>
               <select
                 value={sel[f.key] ?? ""}
                 onChange={(e) => setSel((s) => ({ ...s, [f.key]: e.target.value }))}
-                className="rounded-lg border border-white/10 bg-white/5 px-2.5 py-1.5 outline-none focus:border-emerald-400"
+                className="rounded-lg border border-line bg-surface-2 px-2.5 py-1.5 outline-none focus:border-ink"
               >
                 <option value="">全部</option>
                 {options[f.key]?.map((v) => (
@@ -108,13 +108,13 @@ export default function Leaderboard({
               </select>
             </label>
           ))}
-          <span className="self-center text-xs text-white/30">{view.length} 筆</span>
+          <span className="self-center text-xs text-faint">{view.length} 筆</span>
         </div>
       )}
 
-      <div className="overflow-x-auto rounded-xl border border-white/10">
+      <div className="overflow-x-auto rounded-xl border border-line">
         <table className="w-full text-sm">
-          <thead className="bg-white/5 text-left text-white/50">
+          <thead className="bg-surface-2 text-left text-muted">
             <tr>
               <th className="px-2.5 py-3 font-medium">#</th>
               {cols.map((c) => {
@@ -133,12 +133,12 @@ export default function Leaderboard({
                     onMouseLeave={() => setTip(null)}
                     className={`whitespace-nowrap px-2.5 py-3 font-medium ${
                       sortable ? "cursor-pointer select-none hover:text-white" : ""
-                    } ${c.tip ? "underline decoration-white/25 decoration-dotted underline-offset-4" : ""} ${
-                      active ? "text-emerald-400" : ""
+                    } ${c.tip ? "underline decoration-line decoration-dotted underline-offset-4" : ""} ${
+                      active ? "text-accent" : ""
                     }`}
                   >
                     {c.label}
-                    {active ? (dir === -1 ? " ↓" : " ↑") : sortable ? <span className="text-white/15"> ↕</span> : ""}
+                    {active ? (dir === -1 ? " ↓" : " ↑") : sortable ? <span className="text-faint"> ↕</span> : ""}
                   </th>
                 );
               })}
@@ -146,8 +146,8 @@ export default function Leaderboard({
           </thead>
           <tbody className="font-mono tabular-nums">
             {view.map((r, i) => (
-              <tr key={i} className="border-t border-white/5 hover:bg-white/5">
-                <td className="px-2.5 py-2.5 text-white/40">{i + 1}</td>
+              <tr key={i} className="border-t border-line hover:bg-surface-2">
+                <td className="px-2.5 py-2.5 text-faint">{i + 1}</td>
                 {cols.map((c) => (
                   <td
                     key={c.key}
@@ -158,7 +158,7 @@ export default function Leaderboard({
                     {c.link ? (
                       <Link
                         href={`${c.link.base}${r[c.link.idKey]}`}
-                        className="text-emerald-400 hover:underline"
+                        className="text-accent hover:underline"
                       >
                         {fmtVal(r[c.key], c.fmt)}
                       </Link>
@@ -175,7 +175,7 @@ export default function Leaderboard({
 
       {tip && (
         <div
-          className="pointer-events-none fixed z-50 max-w-xs rounded-md border border-white/10 bg-zinc-800 px-2.5 py-1.5 text-xs leading-relaxed text-white shadow-xl"
+          className="pointer-events-none fixed z-50 max-w-xs rounded-md border border-line bg-zinc-800 px-2.5 py-1.5 text-xs leading-relaxed text-white shadow-xl"
           style={{ left: tip.x + 14, top: tip.y + 16 }}
         >
           {tip.text}

--- a/web/src/components/matchup-card.tsx
+++ b/web/src/components/matchup-card.tsx
@@ -28,24 +28,24 @@ export function MatchupCard({
   const homePct = prob * 100;
 
   return (
-    <div className="rounded-xl border border-white/10 bg-white/[0.02]">
+    <div className="rounded-xl border border-line bg-surface">
       <button
         onClick={() => setOpen((o) => !o)}
         className="flex w-full items-center gap-3 px-4 py-3 text-left"
       >
         {m.game_date && (
-          <span className="w-12 shrink-0 text-xs text-white/40">{m.game_date.slice(5)}</span>
+          <span className="w-12 shrink-0 text-xs text-faint">{m.game_date.slice(5)}</span>
         )}
         <span className="flex-1 text-right text-sm">
-          {m.away.name} <span className="text-white/30">{m.away.record}</span>
+          {m.away.name} <span className="text-faint">{m.away.record}</span>
         </span>
         {/* 客隊(左,紅)｜主隊(右,綠)：綠色從右邊長出，與右側主隊對齊 */}
-        <div className="relative h-7 w-44 shrink-0 overflow-hidden rounded bg-rose-500/30">
+        <div className="relative h-7 w-44 shrink-0 overflow-hidden rounded bg-accent">
           <div
-            className="absolute right-0 top-0 h-7 bg-emerald-500/50"
+            className="absolute right-0 top-0 h-7 bg-ink/50"
             style={{ width: `${homePct}%` }}
           />
-          <span className="absolute inset-y-0 left-2 flex items-center font-mono text-[11px] text-white/55">
+          <span className="absolute inset-y-0 left-2 flex items-center font-mono text-[11px] text-muted">
             {(100 - homePct).toFixed(0)}
           </span>
           <span className="absolute inset-y-0 right-2 flex items-center font-mono text-xs font-bold text-white">
@@ -53,25 +53,25 @@ export function MatchupCard({
           </span>
         </div>
         <span className="flex-1 text-sm">
-          {m.home.name} <span className="text-white/30">{m.home.record}</span>
-          <span className="ml-1 text-xs text-emerald-400/70">(主)</span>
+          {m.home.name} <span className="text-faint">{m.home.record}</span>
+          <span className="ml-1 text-xs text-accent/70">(主)</span>
         </span>
-        <span className="w-4 text-white/30">{open ? "▾" : "▸"}</span>
+        <span className="w-4 text-faint">{open ? "▾" : "▸"}</span>
       </button>
 
       {open && (
-        <div className="border-t border-white/5 px-4 py-3">
+        <div className="border-t border-line px-4 py-3">
           {/* 先發投手 */}
           <div className="mb-3 grid grid-cols-[1fr_auto_1fr] items-center gap-x-4 text-xs">
             <div className="text-right text-amber-300/80">{starterText(m.away.starter ?? null)}</div>
-            <div className="text-white/30">先發</div>
+            <div className="text-faint">先發</div>
             <div className="text-amber-300/80">{starterText(m.home.starter ?? null)}</div>
           </div>
 
           <div className="grid grid-cols-[1fr_auto_1fr] items-center gap-x-4 text-sm">
-            <div className="text-right text-xs text-white/40">{m.away.name}</div>
-            <div className="text-center text-xs text-white/30">變因</div>
-            <div className="text-xs text-white/40">{m.home.name}</div>
+            <div className="text-right text-xs text-faint">{m.away.name}</div>
+            <div className="text-center text-xs text-faint">變因</div>
+            <div className="text-xs text-faint">{m.home.name}</div>
 
             {m.factors
               .filter((f) => f.key !== "home_field")
@@ -81,13 +81,13 @@ export function MatchupCard({
                 return (
                   <div key={f.key} className="contents">
                     <div
-                      className={`text-right font-mono tabular-nums ${awayFav ? "font-bold text-emerald-400" : "text-white/60"}`}
+                      className={`text-right font-mono tabular-nums ${awayFav ? "font-bold text-accent" : "text-muted"}`}
                     >
                       {fmt(f.key, f.away_val ?? (f.key === "h2h_home" ? 1 - m.h2h_home : null))}
                     </div>
-                    <div className="text-center text-xs text-white/40">{f.label}</div>
+                    <div className="text-center text-xs text-faint">{f.label}</div>
                     <div
-                      className={`font-mono tabular-nums ${homeFav ? "font-bold text-emerald-400" : "text-white/60"}`}
+                      className={`font-mono tabular-nums ${homeFav ? "font-bold text-accent" : "text-muted"}`}
                     >
                       {fmt(f.key, f.home_val)}
                     </div>

--- a/web/src/components/spray-chart.tsx
+++ b/web/src/components/spray-chart.tsx
@@ -1,0 +1,44 @@
+// 擊球落點圖（SVG）：用 TrackMan bearing(方向)＋distance(距離)。本壘在底部中央，
+// 球場向上扇形展開；點以擊球初速著色（藍↔紅）。
+import { prColor } from "@/components/ui";
+
+export type SprayPoint = { dir: number; dist: number; ev: number | null };
+
+export function SprayChart({ points, evMin = 100, evMax = 175 }: { points: SprayPoint[]; evMin?: number; evMax?: number }) {
+  const W = 320, H = 300, cx = W / 2, baseY = H - 18;
+  const maxDist = 130; // m
+  const scale = (H - 40) / maxDist;
+  const foul = 45 * (Math.PI / 180);
+  const pt = (deg: number, dist: number) => {
+    const r = (deg * Math.PI) / 180;
+    return [cx + dist * scale * Math.sin(r), baseY - dist * scale * Math.cos(r)] as const;
+  };
+  const [lfx, lfy] = pt(-foul * (180 / Math.PI), maxDist);
+  const [rfx, rfy] = pt(foul * (180 / Math.PI), maxDist);
+  const evColor = (ev: number | null) =>
+    ev == null ? "#94a3b8" : prColor(Math.max(0, Math.min(100, ((ev - evMin) / (evMax - evMin)) * 100)));
+
+  return (
+    <svg viewBox={`0 0 ${W} ${H}`} className="w-full">
+      {/* 外野弧 */}
+      <path d={`M ${lfx} ${lfy} A ${maxDist * scale} ${maxDist * scale} 0 0 1 ${rfx} ${rfy}`}
+        fill="#eef2f7" stroke="#cbd5e1" strokeWidth={1} />
+      {/* 邊線 */}
+      <line x1={cx} y1={baseY} x2={lfx} y2={lfy} stroke="#cbd5e1" strokeWidth={1} />
+      <line x1={cx} y1={baseY} x2={rfx} y2={rfy} stroke="#cbd5e1" strokeWidth={1} />
+      {/* 內野菱形 */}
+      {(() => {
+        const b = 27; // 壘間約 27m
+        const [s1x, s1y] = pt(-45, b), [s2x, s2y] = pt(0, b * 1.414), [s3x, s3y] = pt(45, b);
+        return <polygon points={`${cx},${baseY} ${s1x},${s1y} ${s2x},${s2y} ${s3x},${s3y}`}
+          fill="none" stroke="#cbd5e1" strokeWidth={1} />;
+      })()}
+      {points.map((p, i) => {
+        const [x, y] = pt(p.dir, p.dist);
+        return <circle key={i} cx={x} cy={y} r={3} fill={evColor(p.ev)} fillOpacity={0.8} />;
+      })}
+      <text x={10} y={H - 4} className="fill-faint" fontSize={10}>左外野</text>
+      <text x={W - 42} y={H - 4} className="fill-faint" fontSize={10}>右外野</text>
+    </svg>
+  );
+}

--- a/web/src/components/ui.tsx
+++ b/web/src/components/ui.tsx
@@ -1,0 +1,48 @@
+import { teamColor } from "@/lib/teams";
+
+export function Card({ className = "", children }: { className?: string; children: React.ReactNode }) {
+  return <div className={`card p-4 ${className}`}>{children}</div>;
+}
+
+export function StatTile({ label, value, accent }: { label: string; value: string; accent?: boolean }) {
+  return (
+    <div className="card px-3 py-2.5 text-center">
+      <div className="text-[11px] text-muted">{label}</div>
+      <div className={`mt-0.5 font-mono text-lg tabular-nums ${accent ? "text-accent" : "text-ink"}`}>{value}</div>
+    </div>
+  );
+}
+
+export function TeamBadge({ code, name }: { code?: string | null; name?: string | null }) {
+  return (
+    <span className="inline-flex items-center gap-1.5">
+      <span className="inline-block h-3.5 w-1 rounded-sm" style={{ background: teamColor(code) }} />
+      <span>{name}</span>
+    </span>
+  );
+}
+
+// 百分位發散色階：0=藍 50=灰 100=紅（Baseball Savant 式）
+export function prColor(pr: number): string {
+  const lerp = (a: number, b: number, t: number) => Math.round(a + (b - a) * t);
+  const hex = (r: number, g: number, b: number) => `rgb(${r},${g},${b})`;
+  if (pr <= 50) {
+    const t = pr / 50; // #1E5BB8 → #E8E8E8
+    return hex(lerp(30, 232, t), lerp(91, 232, t), lerp(184, 232, t));
+  }
+  const t = (pr - 50) / 50; // #E8E8E8 → #C4122F
+  return hex(lerp(232, 196, t), lerp(232, 18, t), lerp(232, 47, t));
+}
+
+export function PercentileBar({ name, value, pr, def }: { name: string; value: string; pr: number; def?: string }) {
+  return (
+    <div className="flex items-center gap-2.5 text-sm">
+      <span title={def} className={`w-20 shrink-0 text-muted ${def ? "cursor-help" : ""}`}>{name}</span>
+      <div className="relative h-4 flex-1 overflow-hidden rounded bg-surface-2">
+        <div className="h-full rounded" style={{ width: `${pr}%`, background: prColor(pr) }} />
+      </div>
+      <span className="w-12 shrink-0 text-right font-mono tabular-nums text-ink">{value}</span>
+      <span className="w-9 shrink-0 text-right font-mono text-xs text-faint">{pr}</span>
+    </div>
+  );
+}

--- a/web/src/components/zone-scatter.tsx
+++ b/web/src/components/zone-scatter.tsx
@@ -1,0 +1,31 @@
+// 進壘點散布（SVG，捕手視角）：好球帶近似框 + 每球點（揮空紅/揮棒藍/未揮棒灰）。
+export type ZonePoint = { x: number; y: number; sw: boolean; wh: boolean };
+
+export function ZoneScatter({ points }: { points: ZonePoint[] }) {
+  const W = 260, H = 300, pad = 16;
+  const xMin = -0.8, xMax = 0.8, yMin = -0.2, yMax = 1.7;
+  const sx = (x: number) => pad + ((x - xMin) / (xMax - xMin)) * (W - 2 * pad);
+  const sy = (y: number) => H - pad - ((y - yMin) / (yMax - yMin)) * (H - 2 * pad);
+  // 好球帶（校準值 side±0.21、高 0.5–1.0）
+  const z = { x1: sx(-0.21), x2: sx(0.21), y1: sy(1.0), y2: sy(0.5) };
+
+  return (
+    <svg viewBox={`0 0 ${W} ${H}`} className="w-full">
+      <rect x={z.x1} y={z.y1} width={z.x2 - z.x1} height={z.y2 - z.y1}
+        fill="#eef2f7" stroke="#94a3b8" strokeWidth={1.2} />
+      {/* 九宮格分隔 */}
+      {[1, 2].map((i) => (
+        <g key={i} stroke="#cbd5e1" strokeWidth={0.5}>
+          <line x1={z.x1 + ((z.x2 - z.x1) / 3) * i} y1={z.y1} x2={z.x1 + ((z.x2 - z.x1) / 3) * i} y2={z.y2} />
+          <line x1={z.x1} y1={z.y1 + ((z.y2 - z.y1) / 3) * i} x2={z.x2} y2={z.y1 + ((z.y2 - z.y1) / 3) * i} />
+        </g>
+      ))}
+      {points.map((p, i) => (
+        <circle key={i} cx={sx(p.x)} cy={sy(p.y)} r={2.6}
+          fill={p.wh ? "#d62839" : p.sw ? "#1d6fb8" : "#cbd5e1"}
+          fillOpacity={p.sw ? 0.85 : 0.5} />
+      ))}
+      <text x={W / 2} y={H - 2} textAnchor="middle" className="fill-faint" fontSize={9}>捕手視角</text>
+    </svg>
+  );
+}

--- a/web/src/lib/client.ts
+++ b/web/src/lib/client.ts
@@ -131,9 +131,11 @@ export const detail = {
   advanced: (id: string) =>
     clientGet<{ batting: StatRow | null; pitching: StatRow | null }>(`/api/v1/players/${id}/advanced`),
   discipline: (id: string, role: "batting" | "pitching") =>
-    clientGet<{ summary: Record<string, number | null>; points: { x: number; y: number; sw: boolean; wh: boolean }[] }>(
-      `/api/v1/players/${id}/discipline?role=${role}`,
-    ),
+    clientGet<{
+      summary: Record<string, number | null>;
+      points: { x: number; y: number; sw: boolean; wh: boolean }[];
+      spray: { dir: number; dist: number; ev: number | null }[];
+    }>(`/api/v1/players/${id}/discipline?role=${role}`),
   gameLive: (sno: number, kind = "A") =>
     clientGet<{ game: StatRow | null; scoreboard: StatRow[]; livelog: StatRow[] }>(
       `/api/v1/games/${sno}/live?kind_code=${kind}`,

--- a/web/src/lib/teams.ts
+++ b/web/src/lib/teams.ts
@@ -1,0 +1,22 @@
+// 六隊品牌色與簡稱（hero/badge/隊色條用）。key = team_code（ClubNo+011）。
+export type TeamMeta = { short: string; color: string };
+
+export const TEAMS: Record<string, TeamMeta> = {
+  AAA011: { short: "味全", color: "#C8102E" }, // 味全龍
+  ACN011: { short: "兄弟", color: "#D8A400" }, // 中信兄弟
+  ADD011: { short: "統一", color: "#EA5413" }, // 統一7-ELEVEn獅
+  AEO011: { short: "富邦", color: "#1D3C8B" }, // 富邦悍將
+  AJL011: { short: "樂天", color: "#9B1B30" }, // 樂天桃猿
+  AKP011: { short: "台鋼", color: "#00843D" }, // 台鋼雄鷹
+};
+
+export const teamColor = (code?: string | null) => (code && TEAMS[code]?.color) || "#0A2540";
+export const teamShort = (code?: string | null) => (code && TEAMS[code]?.short) || "";
+
+// 依隊名反查（資料常只有中文隊名）
+const NAME_CODE: Record<string, string> = {
+  味全龍: "AAA011", 中信兄弟: "ACN011", "統一7-ELEVEn獅": "ADD011",
+  富邦悍將: "AEO011", 樂天桃猿: "AJL011", 台鋼雄鷹: "AKP011",
+};
+export const codeFromName = (name?: string | null) => (name && NAME_CODE[name]) || null;
+export const colorFromName = (name?: string | null) => teamColor(codeFromName(name));


### PR DESCRIPTION
## P1 設計系統（日間 Navy+白）
- Tailwind v4 @theme tokens：paper/surface/ink/muted/line/accent/up/down
- 隊色對照 `teams.ts`；元件 Card/StatTile/TeamBadge/**PercentileBar（藍↔紅發散色階）**

## P2 球員頁旗艦（仿 Baseball Savant）
- 隊色 Hero + 本季成績卡
- **官方百分位滑桿**（發散色，TrackMan PR）
- **擊球落點 SprayChart**（bearing×distance，初速著色）+ **進壘點 ZoneScatter**（揮棒/揮空/未揮棒 + 好球帶框）
- 逐月趨勢（指標可選）+ 分項（本季/生涯）
- `/discipline` 端點加回傳 spray（擊球方向/距離/初速）

## 全站淺色化
導覽 + 其餘頁（首頁/排行/賽事/對戰/分項/預測）機械式轉語意色，先確保可讀；逐頁視覺化升級列為 P3。

## 驗證
11 頁全 200、tsc/ruff 通過、零殘留深色 class。

🤖 Generated with [Claude Code](https://claude.com/claude-code)