### PR TITLE
feat: 隊伍徽章（隊色+字母，免logo版權）

### DIFF
--- a/web/src/app/batters/page.tsx
+++ b/web/src/app/batters/page.tsx
@@ -5,7 +5,7 @@ export const dynamic = "force-dynamic";
 
 const COLS: Col[] = [
   { key: "name", label: "球員", tip: "球員姓名（點擊看個人頁）", link: { base: "/players/", idKey: "player_id" } },
-  { key: "team", label: "隊", tone: "dim", tip: "所屬球隊" },
+  { key: "team", label: "隊", team: true, tip: "所屬球隊" },
   { key: "g", label: "出賽", fmt: "i", tone: "dim", tip: "出賽場數（G）" },
   { key: "pa", label: "打席", fmt: "i", tip: "打席（PA）：打數＋四壞＋死球＋犧牲打／高飛犧牲" },
   { key: "ab", label: "打數", fmt: "i", tone: "dim", tip: "打數（AB）：不含四壞、死球、犧牲" },

--- a/web/src/app/fielding/page.tsx
+++ b/web/src/app/fielding/page.tsx
@@ -5,7 +5,7 @@ export const dynamic = "force-dynamic";
 
 const COLS: Col[] = [
   { key: "name", label: "球員", tip: "球員姓名（點擊看個人頁）", link: { base: "/players/", idKey: "player_id" } },
-  { key: "team", label: "隊", tone: "dim", tip: "所屬球隊" },
+  { key: "team", label: "隊", team: true, tip: "所屬球隊" },
   { key: "pos", label: "守位", tip: "守備位置" },
   { key: "g", label: "出賽", fmt: "i", tone: "dim", tip: "該守位出賽場數（G）" },
   { key: "tc", label: "守備機會", fmt: "i", tip: "守備機會 TC = 刺殺＋助殺＋失誤" },

--- a/web/src/app/games/page.tsx
+++ b/web/src/app/games/page.tsx
@@ -1,4 +1,5 @@
 import Link from "next/link";
+import { TeamLogo } from "@/components/ui";
 import { api } from "@/lib/api";
 
 export const dynamic = "force-dynamic";
@@ -34,12 +35,12 @@ export default async function GamesPage() {
                     href={`/games/${g.game_sno}?kind=${g.kind_code}`}
                     className="flex items-center justify-between rounded-xl border border-line bg-surface px-4 py-3 hover:bg-surface-2"
                   >
-                    <div className="space-y-1">
-                      <div className={awayWin ? "font-semibold" : "text-muted"}>
-                        {g.away_team_name}
+                    <div className="space-y-1.5">
+                      <div className={`flex items-center gap-2 ${awayWin ? "font-semibold" : "text-muted"}`}>
+                        <TeamLogo code={g.away_team_code} size={18} />{g.away_team_name}
                       </div>
-                      <div className={!awayWin ? "font-semibold" : "text-muted"}>
-                        {g.home_team_name}
+                      <div className={`flex items-center gap-2 ${!awayWin ? "font-semibold" : "text-muted"}`}>
+                        <TeamLogo code={g.home_team_code} size={18} />{g.home_team_name}
                       </div>
                     </div>
                     <div className="space-y-1 text-right font-mono tabular-nums">

--- a/web/src/app/page.tsx
+++ b/web/src/app/page.tsx
@@ -1,4 +1,5 @@
 import Link from "next/link";
+import { TeamBadge, TeamLogo } from "@/components/ui";
 import { api } from "@/lib/api";
 
 export const dynamic = "force-dynamic";
@@ -8,10 +9,6 @@ const SEGS = [
   { v: 1, label: "上半季" },
   { v: 2, label: "下半季" },
 ];
-
-const ABBR: Record<string, string> = {
-  AAA011: "味全", ACN011: "兄弟", ADD011: "統一", AEO011: "富邦", AJL011: "樂天", AKP011: "台鋼",
-};
 
 export default async function Home({ searchParams }: { searchParams: Promise<{ seg?: string }> }) {
   const { seg = "0" } = await searchParams;
@@ -64,7 +61,7 @@ export default async function Home({ searchParams }: { searchParams: Promise<{ s
                 return (
                   <tr key={t.team_code} className="border-t border-line hover:bg-surface-2">
                     <td className="px-2.5 py-2.5 text-faint">{t.rank}</td>
-                    <td className="whitespace-nowrap px-2.5 py-2.5 font-sans">{t.team_name}</td>
+                    <td className="whitespace-nowrap px-2.5 py-2.5 font-sans"><TeamBadge code={t.team_code} name={t.team_name} /></td>
                     <td className="px-2.5 py-2.5 text-muted">{t.g}</td>
                     <td className="px-2.5 py-2.5">{t.w}-{t.t}-{t.l}</td>
                     <td className="px-2.5 py-2.5 text-accent">{t.win_pct?.toFixed(3) ?? "—"}</td>
@@ -94,14 +91,16 @@ export default async function Home({ searchParams }: { searchParams: Promise<{ s
                 <tr>
                   <th className="whitespace-nowrap px-2.5 py-3 font-medium">球隊＼對手</th>
                   {items.map((c) => (
-                    <th key={c.team_code} className="px-2.5 py-3 text-center font-medium">{ABBR[c.team_code] ?? c.team_name}</th>
+                    <th key={c.team_code} className="px-2.5 py-3 text-center font-medium">
+                      <span className="inline-flex flex-col items-center gap-1"><TeamLogo code={c.team_code} size={20} /></span>
+                    </th>
                   ))}
                 </tr>
               </thead>
               <tbody className="font-mono tabular-nums">
                 {items.map((row) => (
                   <tr key={row.team_code} className="border-t border-line hover:bg-surface-2">
-                    <td className="whitespace-nowrap px-2.5 py-2.5 font-sans">{row.team_name}</td>
+                    <td className="whitespace-nowrap px-2.5 py-2.5 font-sans"><TeamBadge code={row.team_code} name={row.team_name} /></td>
                     {items.map((col) => (
                       <td key={col.team_code} className="px-2.5 py-2.5 text-center text-muted">
                         {col.team_code === row.team_code ? (

--- a/web/src/app/pitchers/page.tsx
+++ b/web/src/app/pitchers/page.tsx
@@ -5,7 +5,7 @@ export const dynamic = "force-dynamic";
 
 const COLS: Col[] = [
   { key: "name", label: "球員", tip: "球員姓名（點擊看個人頁）", link: { base: "/players/", idKey: "player_id" } },
-  { key: "team", label: "隊", tone: "dim", tip: "所屬球隊" },
+  { key: "team", label: "隊", team: true, tip: "所屬球隊" },
   { key: "g", label: "出賽", fmt: "i", tone: "dim", tip: "出賽場數（G）" },
   { key: "gs", label: "先發", fmt: "i", tone: "dim", tip: "先發場數" },
   { key: "cg", label: "完投", fmt: "i", tone: "dim", tip: "完投：先發且投完全場" },

--- a/web/src/app/players/[id]/page.tsx
+++ b/web/src/app/players/[id]/page.tsx
@@ -5,7 +5,7 @@ import { useParams } from "next/navigation";
 import { useEffect, useMemo, useState } from "react";
 import { CartesianGrid, Line, LineChart, ResponsiveContainer, Tooltip, XAxis, YAxis } from "recharts";
 import { SprayChart } from "@/components/spray-chart";
-import { Card, PercentileBar, StatTile, TeamBadge } from "@/components/ui";
+import { Card, PercentileBar, StatTile, TeamLogo } from "@/components/ui";
 import { ZoneScatter } from "@/components/zone-scatter";
 import { detail, type PlayerProfile, type StatRow } from "@/lib/client";
 import { codeFromName, teamColor } from "@/lib/teams";
@@ -155,13 +155,16 @@ export default function PlayerPage() {
       <div className="card mb-6 overflow-hidden">
         <div className="h-1.5" style={{ background: teamColor(tc) }} />
         <div className="flex flex-wrap items-end justify-between gap-4 p-5">
-          <div>
-            <h1 className="text-3xl font-bold text-ink">{profile.name}</h1>
-            <p className="mt-1 text-sm text-muted">
-              <TeamBadge code={tc} name={profile.team} />
-              {profile.bats && <span className="ml-3">打 {profile.bats}</span>}
-              {profile.throws && <span className="ml-2">投 {profile.throws}</span>}
-            </p>
+          <div className="flex items-center gap-3.5">
+            <TeamLogo code={tc} size={48} />
+            <div>
+              <h1 className="text-3xl font-bold text-ink">{profile.name}</h1>
+              <p className="mt-1 text-sm text-muted">
+                {profile.team}
+                {profile.bats && <span className="ml-3">打 {profile.bats}</span>}
+                {profile.throws && <span className="ml-2">投 {profile.throws}</span>}
+              </p>
+            </div>
           </div>
           {s && role === "batting" && (
             <div className="font-mono text-lg tabular-nums text-ink">

--- a/web/src/components/leaderboard.tsx
+++ b/web/src/components/leaderboard.tsx
@@ -2,6 +2,8 @@
 
 import Link from "next/link";
 import { useMemo, useState } from "react";
+import { TeamBadge } from "@/components/ui";
+import { codeFromName } from "@/lib/teams";
 
 export type Fmt = "i" | "f1" | "f2" | "f3";
 export type Tone = "accent" | "dim" | "warn";
@@ -16,6 +18,7 @@ export type Col = {
   // 若提供，該儲存格渲染成連結 href = base + row[idKey]（如球員名→個人頁）。
   // 用可序列化物件而非函式，server component 才能把 Col 傳給此 client 元件。
   link?: { base: string; idKey: string };
+  team?: boolean; // 該欄值為隊名時，渲染隊徽 + 名稱
 };
 
 export type Filter = { key: string; label: string };
@@ -132,7 +135,7 @@ export default function Leaderboard({
                     }
                     onMouseLeave={() => setTip(null)}
                     className={`whitespace-nowrap px-2.5 py-3 font-medium ${
-                      sortable ? "cursor-pointer select-none hover:text-white" : ""
+                      sortable ? "cursor-pointer select-none hover:text-ink" : ""
                     } ${c.tip ? "underline decoration-line decoration-dotted underline-offset-4" : ""} ${
                       active ? "text-accent" : ""
                     }`}
@@ -152,10 +155,12 @@ export default function Leaderboard({
                   <td
                     key={c.key}
                     className={`whitespace-nowrap px-2.5 py-2.5 ${c.fmt ? "" : "font-sans"} ${
-                      c.key === sortKey ? "text-white" : toneCls(c.tone)
+                      c.key === sortKey ? "font-medium text-ink" : toneCls(c.tone)
                     }`}
                   >
-                    {c.link ? (
+                    {c.team ? (
+                      <TeamBadge code={codeFromName(String(r[c.key]))} name={String(r[c.key] ?? "—")} size={16} />
+                    ) : c.link ? (
                       <Link
                         href={`${c.link.base}${r[c.link.idKey]}`}
                         className="text-accent hover:underline"

--- a/web/src/components/ui.tsx
+++ b/web/src/components/ui.tsx
@@ -1,4 +1,18 @@
-import { teamColor } from "@/lib/teams";
+import { contrastText, teamColor, teamLetter } from "@/lib/teams";
+
+// 隊伍徽章：隊色圓角方塊 + 英文字母（避免官方 logo 版權）。
+export function TeamLogo({ code, size = 24 }: { code?: string | null; size?: number }) {
+  const bg = teamColor(code);
+  return (
+    <span
+      className="inline-flex shrink-0 items-center justify-center rounded-md font-extrabold leading-none"
+      style={{ width: size, height: size, background: bg, color: contrastText(bg), fontSize: size * 0.56 }}
+      aria-label="隊徽"
+    >
+      {teamLetter(code)}
+    </span>
+  );
+}
 
 export function Card({ className = "", children }: { className?: string; children: React.ReactNode }) {
   return <div className={`card p-4 ${className}`}>{children}</div>;
@@ -13,11 +27,11 @@ export function StatTile({ label, value, accent }: { label: string; value: strin
   );
 }
 
-export function TeamBadge({ code, name }: { code?: string | null; name?: string | null }) {
+export function TeamBadge({ code, name, size = 20 }: { code?: string | null; name?: string | null; size?: number }) {
   return (
     <span className="inline-flex items-center gap-1.5">
-      <span className="inline-block h-3.5 w-1 rounded-sm" style={{ background: teamColor(code) }} />
-      <span>{name}</span>
+      <TeamLogo code={code} size={size} />
+      {name && <span>{name}</span>}
     </span>
   );
 }

--- a/web/src/lib/teams.ts
+++ b/web/src/lib/teams.ts
@@ -1,17 +1,27 @@
-// 六隊品牌色與簡稱（hero/badge/隊色條用）。key = team_code（ClubNo+011）。
-export type TeamMeta = { short: string; color: string };
+// 六隊品牌色、簡稱、字母徽章（避免官方 logo 版權，以隊色＋字母代表）。
+// 字母取隊伍英文代表字：W=味全(Wei Chuan)、B=兄弟(Brothers)、L=獅(Lions)、
+// G=悍將(Guardians)、M=猿(Monkeys)、H=鷹(Hawks)。key = team_code（ClubNo+011）。
+export type TeamMeta = { short: string; color: string; letter: string };
 
 export const TEAMS: Record<string, TeamMeta> = {
-  AAA011: { short: "味全", color: "#C8102E" }, // 味全龍
-  ACN011: { short: "兄弟", color: "#D8A400" }, // 中信兄弟
-  ADD011: { short: "統一", color: "#EA5413" }, // 統一7-ELEVEn獅
-  AEO011: { short: "富邦", color: "#1D3C8B" }, // 富邦悍將
-  AJL011: { short: "樂天", color: "#9B1B30" }, // 樂天桃猿
-  AKP011: { short: "台鋼", color: "#00843D" }, // 台鋼雄鷹
+  AAA011: { short: "味全", color: "#C8102E", letter: "W" }, // 味全龍
+  ACN011: { short: "兄弟", color: "#D8A400", letter: "B" }, // 中信兄弟
+  ADD011: { short: "統一", color: "#EA5413", letter: "L" }, // 統一7-ELEVEn獅
+  AEO011: { short: "富邦", color: "#1D3C8B", letter: "G" }, // 富邦悍將
+  AJL011: { short: "樂天", color: "#9B1B30", letter: "M" }, // 樂天桃猿
+  AKP011: { short: "台鋼", color: "#00843D", letter: "H" }, // 台鋼雄鷹
 };
 
 export const teamColor = (code?: string | null) => (code && TEAMS[code]?.color) || "#0A2540";
 export const teamShort = (code?: string | null) => (code && TEAMS[code]?.short) || "";
+export const teamLetter = (code?: string | null) => (code && TEAMS[code]?.letter) || "?";
+
+// 依背景色亮度回傳對比文字色（黃色系用深色字）
+export function contrastText(hex: string): string {
+  const n = hex.replace("#", "");
+  const r = parseInt(n.slice(0, 2), 16), g = parseInt(n.slice(2, 4), 16), b = parseInt(n.slice(4, 6), 16);
+  return (0.299 * r + 0.587 * g + 0.114 * b) / 255 > 0.6 ? "#0A2540" : "#FFFFFF";
+}
 
 // 依隊名反查（資料常只有中文隊名）
 const NAME_CODE: Record<string, string> = {


### PR DESCRIPTION
以隊色圓角徽章＋英文字母代表球隊（W味全/B兄弟/L統一/G富邦/M樂天/H台鋼），避開官方 logo 版權。套用於球員頁 Hero、首頁戰績/H2H、賽事列表、排行榜隊伍欄；黃色系自動深色字對比。

🤖 Generated with [Claude Code](https://claude.com/claude-code)