### PR TITLE
feat: 球員頁百分位精簡雙欄（提高資訊密度）

### DIFF
--- a/web/src/app/players/[id]/page.tsx
+++ b/web/src/app/players/[id]/page.tsx
@@ -183,7 +183,7 @@ export default function PlayerPage() {
 
       {/* 本季成績卡 */}
       {s && (
-        <section className="mb-8">
+        <section className="mb-6">
           <h2 className="mb-3 text-lg font-semibold text-ink">本季成績</h2>
           <div className="grid grid-cols-3 gap-2 sm:grid-cols-5">
             {(role === "batting"
@@ -202,13 +202,13 @@ export default function PlayerPage() {
       )}
 
       {/* 百分位 */}
-      <section className="mb-8">
+      <section className="mb-6">
         <h2 className="mb-3 text-lg font-semibold text-ink">官方進階數據 · 百分位 PR</h2>
         <Card>
           {prRows.length === 0 ? (
             <p className="py-8 text-center text-sm text-faint">{advanced === null ? "載入中…" : "無官方進階資料"}</p>
           ) : (
-            <div className="space-y-1.5">
+            <div className="grid gap-x-8 gap-y-1.5 sm:grid-cols-2">
               {prRows.map((d) => <PercentileBar key={d.name} name={d.name} value={d.value} pr={d.pr} def={d.def} />)}
             </div>
           )}
@@ -219,7 +219,7 @@ export default function PlayerPage() {
       </section>
 
       {/* 擊球落點 + 進壘點 */}
-      <section className="mb-8 grid gap-6 lg:grid-cols-2">
+      <section className="mb-6 grid gap-6 lg:grid-cols-2">
         <Card>
           <h3 className="mb-2 text-sm font-medium text-muted">擊球落點（點＝擊球初速 藍低→紅高，{disc?.spray.length ?? 0} 球）</h3>
           {disc && disc.spray.length > 0 ? <SprayChart points={disc.spray} />
@@ -240,7 +240,7 @@ export default function PlayerPage() {
       </section>
 
       {/* 範圍切換 + 逐月趨勢 */}
-      <section className="mb-8">
+      <section className="mb-6">
         <div className="mb-3 flex flex-wrap items-center gap-3">
           <Tabs opts={[{ v: "season", label: "本季" }, { v: "career", label: "生涯" }]} v={scope} set={setScope} />
           {scope === "career" && (

--- a/web/src/components/ui.tsx
+++ b/web/src/components/ui.tsx
@@ -50,13 +50,13 @@ export function prColor(pr: number): string {
 
 export function PercentileBar({ name, value, pr, def }: { name: string; value: string; pr: number; def?: string }) {
   return (
-    <div className="flex items-center gap-2.5 text-sm">
-      <span title={def} className={`w-20 shrink-0 text-muted ${def ? "cursor-help" : ""}`}>{name}</span>
-      <div className="relative h-4 flex-1 overflow-hidden rounded bg-surface-2">
-        <div className="h-full rounded" style={{ width: `${pr}%`, background: prColor(pr) }} />
+    <div className="flex items-center gap-2 text-xs">
+      <span title={def} className={`w-16 shrink-0 truncate text-muted ${def ? "cursor-help" : ""}`}>{name}</span>
+      <div className="relative h-2.5 flex-1 overflow-hidden rounded-full bg-surface-2">
+        <div className="h-full rounded-full" style={{ width: `${pr}%`, background: prColor(pr) }} />
       </div>
-      <span className="w-12 shrink-0 text-right font-mono tabular-nums text-ink">{value}</span>
-      <span className="w-9 shrink-0 text-right font-mono text-xs text-faint">{pr}</span>
+      <span className="w-11 shrink-0 text-right font-mono tabular-nums text-ink">{value}</span>
+      <span className="w-6 shrink-0 text-right font-mono text-faint">{pr}</span>
     </div>
   );
 }


### PR DESCRIPTION
PR 條精簡 + 雙欄排列（12→6 列），區塊間距收緊；一眼資訊量加倍仍好讀。

🤖 Generated with [Claude Code](https://claude.com/claude-code)