### PR TITLE
feat: 縮小擊球落點/進壘點圖 + 本季成績加量

### DIFF
--- a/web/src/app/players/[id]/page.tsx
+++ b/web/src/app/players/[id]/page.tsx
@@ -190,13 +190,16 @@ export default function PlayerPage() {
               {(role === "batting"
                 ? [["打擊率", f3(s.avg), true], ["上壘率", f3(s.obp), false], ["長打率", f3(s.slg), false],
                    ["OPS", f3(s.ops), true], ["全壘打", String(s.hr ?? "—"), false], ["打點", String(s.rbi ?? "—"), false],
-                   ["安打", String(s.h ?? "—"), false], ["盜壘", String(s.sb ?? "—"), false], ["打席", String(s.pa ?? "—"), false],
-                   ["出賽", String(s.g ?? "—"), false]]
+                   ["安打", String(s.h ?? "—"), false], ["二安", String(s.b2 ?? "—"), false], ["三安", String(s.b3 ?? "—"), false],
+                   ["得分", String(s.r ?? "—"), false], ["盜壘", String(s.sb ?? "—"), false], ["四壞", String(s.bb ?? "—"), false],
+                   ["三振", String(s.so ?? "—"), false], ["打席", String(s.pa ?? "—"), false], ["出賽", String(s.g ?? "—"), false]]
                 : [["防禦率", numOf(s.era)?.toFixed(2) ?? "—", true], ["WHIP", numOf(s.whip)?.toFixed(2) ?? "—", false],
-                   ["勝-敗", `${s.w ?? 0}-${s.l ?? 0}`, false], ["局數", numOf(s.ip)?.toFixed(1) ?? "—", false],
-                   ["三振", String(s.so ?? "—"), true], ["K9", numOf(s.k9)?.toFixed(2) ?? "—", false],
-                   ["救援", String(s.sv ?? "—"), false], ["中繼", String(s.hld ?? "—"), false],
-                   ["自責", String(s.er ?? "—"), false], ["出賽", String(s.g ?? "—"), false]]
+                   ["勝-敗", `${s.w ?? 0}-${s.l ?? 0}`, false], ["救援", String(s.sv ?? "—"), false],
+                   ["中繼", String(s.hld ?? "—"), false], ["局數", numOf(s.ip)?.toFixed(1) ?? "—", false],
+                   ["先發", String(s.gs ?? "—"), false], ["三振", String(s.so ?? "—"), true],
+                   ["K9", numOf(s.k9)?.toFixed(2) ?? "—", false], ["被安", String(s.h ?? "—"), false],
+                   ["被轟", String(s.hr ?? "—"), false], ["四壞", String(s.bb ?? "—"), false],
+                   ["失分", String(s.r ?? "—"), false], ["自責", String(s.er ?? "—"), false], ["出賽", String(s.g ?? "—"), false]]
               ).map(([l, v, a]) => <StatTile key={l as string} label={l as string} value={v as string} accent={a as boolean} />)}
             </div>
           ) : <p className="text-sm text-muted">本季無{role === "batting" ? "打擊" : "投球"}成績。</p>}
@@ -222,12 +225,12 @@ export default function PlayerPage() {
       <section className="mb-6 grid gap-6 lg:grid-cols-2">
         <Card>
           <h3 className="mb-2 text-sm font-medium text-muted">擊球落點（點＝擊球初速 藍低→紅高，{disc?.spray.length ?? 0} 球）</h3>
-          {disc && disc.spray.length > 0 ? <SprayChart points={disc.spray} />
+          {disc && disc.spray.length > 0 ? <div className="mx-auto max-w-[290px]"><SprayChart points={disc.spray} /></div>
             : <p className="py-12 text-center text-sm text-faint">{disc === null ? "載入中…" : "無擊球追蹤資料"}</p>}
         </Card>
         <Card>
           <h3 className="mb-2 text-sm font-medium text-muted">進壘點（紅＝揮空、藍＝揮棒、灰＝未揮棒，{disc?.points.length ?? 0} 球）</h3>
-          {disc && disc.points.length > 0 ? <ZoneScatter points={disc.points} />
+          {disc && disc.points.length > 0 ? <div className="mx-auto max-w-[250px]"><ZoneScatter points={disc.points} /></div>
             : <p className="py-12 text-center text-sm text-faint">{disc === null ? "載入中…" : "無逐球資料"}</p>}
           {disc && disc.summary.swing_pct != null && (
             <div className="mt-2 flex flex-wrap gap-x-4 gap-y-1 text-xs text-muted">

--- a/web/src/components/spray-chart.tsx
+++ b/web/src/components/spray-chart.tsx
@@ -5,7 +5,7 @@ import { prColor } from "@/components/ui";
 export type SprayPoint = { dir: number; dist: number; ev: number | null };
 
 export function SprayChart({ points, evMin = 100, evMax = 175 }: { points: SprayPoint[]; evMin?: number; evMax?: number }) {
-  const W = 320, H = 300, cx = W / 2, baseY = H - 18;
+  const W = 300, H = 215, cx = W / 2, baseY = H - 14;
   const maxDist = 130; // m
   const scale = (H - 40) / maxDist;
   const foul = 45 * (Math.PI / 180);

--- a/web/src/components/zone-scatter.tsx
+++ b/web/src/components/zone-scatter.tsx
@@ -2,7 +2,7 @@
 export type ZonePoint = { x: number; y: number; sw: boolean; wh: boolean };
 
 export function ZoneScatter({ points }: { points: ZonePoint[] }) {
-  const W = 260, H = 300, pad = 16;
+  const W = 230, H = 215, pad = 14;
   const xMin = -0.8, xMax = 0.8, yMin = -0.2, yMax = 1.7;
   const sx = (x: number) => pad + ((x - xMin) / (xMax - xMin)) * (W - 2 * pad);
   const sy = (y: number) => H - pad - ((y - yMin) / (yMax - yMin)) * (H - 2 * pad);


### PR DESCRIPTION
兩圖縮小（限寬）讓逐月趨勢進螢幕；本季成績補至 15 格。

🤖 Generated with [Claude Code](https://claude.com/claude-code)