### PR TITLE
feat: 球種應對 arsenal（與逐月趨勢並排）

### DIFF
--- a/src/cpbl/api/main.py
+++ b/src/cpbl/api/main.py
@@ -751,3 +751,39 @@ def official_standings(
             (season, kind_code, season_code),
         )
         return {"season": season, "season_code": season_code, "items": _dicts(cur)}
+
+
+@app.get("/api/v1/players/{player_id}/arsenal")
+def player_arsenal(
+    player_id: str,
+    role: str = Query("pitching", pattern="^(batting|pitching)$"),
+    season: int = Query(DEFAULT_SEASON),
+) -> dict:
+    """球種應對：自 pitch_tracking 按球種彙總。pitching=投手配球、batting=打者面對。
+    回每球種：球數、用球/面對%、均速、(投手)轉速、揮空%、(打者)擊球初速。"""
+    col = "pitcher_acnt" if role == "pitching" else "hitter_acnt"
+    with conn() as c:
+        cur = c.cursor()
+        cur.execute(
+            f"""
+            SELECT tagged_pitch_type, count(*) n, avg(rel_speed), avg(spin_rate),
+                   count(*) FILTER (WHERE pitch_call = 'StrikeSwinging'),
+                   count(*) FILTER (WHERE pitch_call IN {_SWING}),
+                   avg(hit_exit_speed)
+            FROM cpbl.pitch_tracking
+            WHERE {col} = %s AND year = %s AND tagged_pitch_type IS NOT NULL
+            GROUP BY tagged_pitch_type ORDER BY n DESC
+            """,
+            (player_id, season),
+        )
+        rows = cur.fetchall()
+    total = sum(r[1] for r in rows) or 1
+    fl = lambda v: round(float(v), 1) if v is not None else None  # noqa: E731
+    items = [
+        {"pitch_type": pt, "n": n, "usage": round(n / total * 100, 1),
+         "avg_speed": fl(spd), "avg_spin": round(float(spin)) if spin is not None else None,
+         "whiff_pct": round(wh / sw * 100, 1) if sw else None,
+         "avg_ev": fl(ev)}
+        for pt, n, spd, spin, wh, sw, ev in rows
+    ]
+    return {"player_id": player_id, "role": role, "items": items}

--- a/web/src/app/players/[id]/page.tsx
+++ b/web/src/app/players/[id]/page.tsx
@@ -83,6 +83,35 @@ function Tabs<T extends string>({ opts, v, set }: { opts: { v: T; label: string 
   );
 }
 
+const PITCH_LABEL: Record<string, string> = { fastball: "速球", breakingball: "變化球" };
+
+function ArsenalTable({ items, role }: { items: StatRow[]; role: Role }) {
+  return (
+    <table className="w-full text-sm">
+      <thead className="text-left text-muted">
+        <tr className="text-xs">
+          <th className="py-1 font-medium">球種</th>
+          <th className="py-1 text-right font-medium">{role === "batting" ? "面對" : "用球"}%</th>
+          <th className="py-1 text-right font-medium">均速</th>
+          <th className="py-1 text-right font-medium">揮空%</th>
+          <th className="py-1 text-right font-medium">擊球初速</th>
+        </tr>
+      </thead>
+      <tbody className="font-mono tabular-nums">
+        {items.map((r) => (
+          <tr key={String(r.pitch_type)} className="border-t border-line">
+            <td className="py-1.5 font-sans text-ink">{PITCH_LABEL[String(r.pitch_type)] ?? String(r.pitch_type)}</td>
+            <td className="py-1.5 text-right">{String(r.usage)}%</td>
+            <td className="py-1.5 text-right">{r.avg_speed ?? "—"}</td>
+            <td className="py-1.5 text-right">{r.whiff_pct ?? "—"}%</td>
+            <td className="py-1.5 text-right text-muted">{r.avg_ev ?? "—"}</td>
+          </tr>
+        ))}
+      </tbody>
+    </table>
+  );
+}
+
 export default function PlayerPage() {
   const { id } = useParams<{ id: string }>();
   const [profile, setProfile] = useState<PlayerProfile | null>(null);
@@ -93,6 +122,7 @@ export default function PlayerPage() {
   const [season, setSeason] = useState<{ batting: StatRow | null; pitching: StatRow | null } | null>(null);
   const [advanced, setAdvanced] = useState<{ batting: StatRow | null; pitching: StatRow | null } | null>(null);
   const [disc, setDisc] = useState<Disc | null>(null);
+  const [arsenal, setArsenal] = useState<StatRow[] | null>(null);
   const [splits, setSplits] = useState<StatRow[] | null>(null);
   const [monthMetric, setMonthMetric] = useState("ops");
 
@@ -109,7 +139,9 @@ export default function PlayerPage() {
   useEffect(() => {
     setMonthMetric(role === "batting" ? "ops" : "era");
     setDisc(null);
+    setArsenal(null);
     detail.discipline(id, role).then((d) => setDisc(d as Disc)).catch(() => setDisc(null));
+    detail.arsenal(id, role).then((d) => setArsenal(d.items)).catch(() => setArsenal([]));
   }, [id, role]);
 
   useEffect(() => {
@@ -260,6 +292,7 @@ export default function PlayerPage() {
             </div>
           )}
         </div>
+        <div className="grid gap-6 lg:grid-cols-2">
         <Card>
           <div className="mb-3 flex items-center justify-between gap-3">
             <h3 className="text-sm font-medium text-muted">逐月趨勢</h3>
@@ -281,6 +314,13 @@ export default function PlayerPage() {
             </ResponsiveContainer>
           )}
         </Card>
+        <Card>
+          <h3 className="mb-3 text-sm font-medium text-muted">球種應對（{role === "batting" ? "面對" : "配球"}；速球/變化球）</h3>
+          {arsenal === null ? <p className="py-8 text-center text-sm text-faint">載入中…</p>
+            : arsenal.length === 0 ? <p className="py-8 text-center text-sm text-faint">無逐球資料</p>
+            : <ArsenalTable items={arsenal} role={role} />}
+        </Card>
+        </div>
       </section>
 
       {/* 分項明細 */}

--- a/web/src/lib/client.ts
+++ b/web/src/lib/client.ts
@@ -128,6 +128,8 @@ export const detail = {
     clientGet<PlayerMatchupsData>(`/api/v1/players/${id}/matchups?role=${role}&kind_code=${kind}`),
   season: (id: string) =>
     clientGet<{ batting: StatRow | null; pitching: StatRow | null }>(`/api/v1/players/${id}/season`),
+  arsenal: (id: string, role: "batting" | "pitching") =>
+    clientGet<{ items: StatRow[] }>(`/api/v1/players/${id}/arsenal?role=${role}`),
   advanced: (id: string) =>
     clientGet<{ batting: StatRow | null; pitching: StatRow | null }>(`/api/v1/players/${id}/advanced`),
   discipline: (id: string, role: "batting" | "pitching") =>


### PR DESCRIPTION
新增 /arsenal 端點（按球種彙總：用球/面對%、均速、揮空%、擊球初速）；官方分類僅速球/變化球。球員頁趨勢｜球種應對並排。

🤖 Generated with [Claude Code](https://claude.com/claude-code)