### PR TITLE
feat: player page charts rework + arsenal/trend endpoints

### DIFF
--- a/src/cpbl/api/main.py
+++ b/src/cpbl/api/main.py
@@ -787,3 +787,82 @@ def player_arsenal(
         for pt, n, spd, spin, wh, sw, ev in rows
     ]
     return {"player_id": player_id, "role": role, "items": items}
+
+
+@app.get("/api/v1/players/{player_id}/trend")
+def player_trend(
+    player_id: str,
+    role: str = Query("batting", pattern="^(batting|pitching)$"),
+    season: int = Query(DEFAULT_SEASON),
+    kind_code: str = Query("A"),
+) -> dict:
+    """逐場「累積季成績」趨勢：逐場依日期累積計數型，並現算 rate stat。
+    比月份桶（最多 ~6 點）細，每場一點且隨賽季收斂到當季數字。"""
+    with conn() as c:
+        cur = c.cursor()
+        if role == "batting":
+            cur.execute(
+                """
+                SELECT g.game_date,
+                    sum(b.at_bats)     OVER w AS ab,
+                    sum(b.hits)        OVER w AS h,
+                    sum(b.bb)          OVER w AS bb,
+                    sum(b.hbp)         OVER w AS hbp,
+                    sum(b.sac_fly)     OVER w AS sf,
+                    sum(b.total_bases) OVER w AS tb,
+                    sum(b.home_runs)   OVER w AS hr,
+                    sum(b.rbi)         OVER w AS rbi
+                FROM cpbl.batting_gamelog b
+                JOIN cpbl.games g
+                  ON g.year = b.year AND g.kind_code = b.kind_code AND g.game_sno = b.game_sno
+                WHERE b.hitter_acnt = %s AND b.year = %s AND b.kind_code = %s
+                WINDOW w AS (ORDER BY g.game_date, b.game_sno
+                             ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW)
+                ORDER BY g.game_date, b.game_sno
+                """,
+                (player_id, season, kind_code),
+            )
+            items = []
+            for i, (d, ab, h, bb, hbp, sf, tb, hr, rbi) in enumerate(cur.fetchall(), 1):
+                ab = ab or 0
+                pa_ob = ab + (bb or 0) + (hbp or 0) + (sf or 0)
+                avg = h / ab if ab else None
+                obp = ((h or 0) + (bb or 0) + (hbp or 0)) / pa_ob if pa_ob else None
+                slg = (tb or 0) / ab if ab else None
+                ops = (obp + slg) if obp is not None and slg is not None else None
+                r3 = lambda v: round(v, 3) if v is not None else None  # noqa: E731
+                items.append({
+                    "name": f"{d.month}/{d.day}", "g": i,
+                    "avg": r3(avg), "obp": r3(obp), "slg": r3(slg), "ops": r3(ops),
+                    "hits": h, "home_runs": hr, "rbi": rbi,
+                })
+        else:
+            cur.execute(
+                """
+                SELECT g.game_date,
+                    sum(p.inning_pitched_cnt)  OVER w AS ipc,
+                    sum(p.inning_pitched_div3) OVER w AS ip3,
+                    sum(p.earned_runs)         OVER w AS er,
+                    sum(p.so)                  OVER w AS so,
+                    sum(p.hits)                OVER w AS h,
+                    sum(p.bb)                  OVER w AS bb
+                FROM cpbl.pitching_gamelog p
+                JOIN cpbl.games g
+                  ON g.year = p.year AND g.kind_code = p.kind_code AND g.game_sno = p.game_sno
+                WHERE p.pitcher_acnt = %s AND p.year = %s AND p.kind_code = %s
+                WINDOW w AS (ORDER BY g.game_date, p.game_sno
+                             ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW)
+                ORDER BY g.game_date, p.game_sno
+                """,
+                (player_id, season, kind_code),
+            )
+            items = []
+            for i, (d, ipc, ip3, er, so, h, bb) in enumerate(cur.fetchall(), 1):
+                ip = (ipc or 0) + (ip3 or 0) / 3
+                era = round((er or 0) * 9 / ip, 2) if ip else None
+                whip = round(((bb or 0) + (h or 0)) / ip, 2) if ip else None
+                items.append({
+                    "name": f"{d.month}/{d.day}", "g": i,
+                    "era": era, "whip": whip, "so": so, "hits": h, "bb": bb,
+                })
+    return {"player_id": player_id, "role": role, "items": items}

--- a/web/src/app/players/[id]/page.tsx
+++ b/web/src/app/players/[id]/page.tsx
@@ -62,7 +62,8 @@ const BAT_METRICS: Metric[] = [
   { key: "rbi", label: "打點", dp: 0, get: (r) => numOf(r.rbi) },
 ];
 const PIT_METRICS: Metric[] = [
-  { key: "era", label: "ERA", dp: 2, get: eraOf },
+  { key: "era", label: "ERA", dp: 2, get: (r) => (r.era != null ? numOf(r.era) : eraOf(r)) },
+  { key: "whip", label: "WHIP", dp: 2, get: (r) => numOf(r.whip) },
   { key: "so", label: "三振", dp: 0, get: (r) => numOf(r.so) },
   { key: "hits", label: "被安打", dp: 0, get: (r) => numOf(r.hits) },
   { key: "bb", label: "四壞", dp: 0, get: (r) => numOf(r.bb) },
@@ -87,9 +88,9 @@ const PITCH_LABEL: Record<string, string> = { fastball: "速球", breakingball: 
 
 function ArsenalTable({ items, role }: { items: StatRow[]; role: Role }) {
   return (
-    <table className="w-full text-sm">
+    <table className="w-full text-xs">
       <thead className="text-left text-muted">
-        <tr className="text-xs">
+        <tr>
           <th className="py-1 font-medium">球種</th>
           <th className="py-1 text-right font-medium">{role === "batting" ? "面對" : "用球"}%</th>
           <th className="py-1 text-right font-medium">均速</th>
@@ -123,6 +124,7 @@ export default function PlayerPage() {
   const [advanced, setAdvanced] = useState<{ batting: StatRow | null; pitching: StatRow | null } | null>(null);
   const [disc, setDisc] = useState<Disc | null>(null);
   const [arsenal, setArsenal] = useState<StatRow[] | null>(null);
+  const [trend, setTrend] = useState<StatRow[] | null>(null);
   const [splits, setSplits] = useState<StatRow[] | null>(null);
   const [monthMetric, setMonthMetric] = useState("ops");
 
@@ -140,8 +142,10 @@ export default function PlayerPage() {
     setMonthMetric(role === "batting" ? "ops" : "era");
     setDisc(null);
     setArsenal(null);
+    setTrend(null);
     detail.discipline(id, role).then((d) => setDisc(d as Disc)).catch(() => setDisc(null));
     detail.arsenal(id, role).then((d) => setArsenal(d.items)).catch(() => setArsenal([]));
+    detail.trend(id, role).then((d) => setTrend(d.items)).catch(() => setTrend([]));
   }, [id, role]);
 
   useEffect(() => {
@@ -158,10 +162,10 @@ export default function PlayerPage() {
   }, [splits]);
   const metrics = role === "batting" ? BAT_METRICS : PIT_METRICS;
   const metric = metrics.find((m) => m.key === monthMetric) ?? metrics[0];
-  const monthData = useMemo(
-    () => MONTHS.filter((mo) => byName[mo]).map((mo) => ({ name: mo.replace("月", ""), v: metric.get(byName[mo]) })),
-    [byName, metric],
-  );
+  const monthData = useMemo(() => {
+    if (scope === "season") return (trend ?? []).map((r) => ({ name: String(r.name), v: metric.get(r) }));
+    return MONTHS.filter((mo) => byName[mo]).map((mo) => ({ name: mo.replace("月", ""), v: metric.get(byName[mo]) }));
+  }, [scope, trend, byName, metric]);
   const prRows = useMemo(() => {
     const a = advanced ? (role === "batting" ? advanced.batting : advanced.pitching) : null;
     if (!a) return [];
@@ -253,25 +257,46 @@ export default function PlayerPage() {
         </div>
       </section>
 
-      {/* 擊球落點 + 進壘點 */}
-      <section className="mb-6 grid gap-6 lg:grid-cols-2">
-        <Card>
-          <h3 className="mb-2 text-sm font-medium text-muted">擊球落點（點＝擊球初速 藍低→紅高，{disc?.spray.length ?? 0} 球）</h3>
-          {disc && disc.spray.length > 0 ? <div className="mx-auto max-w-[290px]"><SprayChart points={disc.spray} /></div>
-            : <p className="py-12 text-center text-sm text-faint">{disc === null ? "載入中…" : "無擊球追蹤資料"}</p>}
-        </Card>
-        <Card>
-          <h3 className="mb-2 text-sm font-medium text-muted">進壘點（紅＝揮空、藍＝揮棒、灰＝未揮棒，{disc?.points.length ?? 0} 球）</h3>
-          {disc && disc.points.length > 0 ? <div className="mx-auto max-w-[250px]"><ZoneScatter points={disc.points} /></div>
-            : <p className="py-12 text-center text-sm text-faint">{disc === null ? "載入中…" : "無逐球資料"}</p>}
-          {disc && disc.summary.swing_pct != null && (
-            <div className="mt-2 flex flex-wrap gap-x-4 gap-y-1 text-xs text-muted">
-              <span>揮棒 {disc.summary.swing_pct}%</span><span>揮空 {disc.summary.whiff_pct}%</span>
-              <span>接觸 {disc.summary.contact_pct}%</span><span>CSW {disc.summary.csw_pct}%</span>
-              <span>追打 {disc.summary.chase_pct}%（近似）</span>
+      {/* 擊球落點 + 進壘點（左 2/3 放大） + 好球帶紀律（右側直欄） */}
+      <section className="mb-6 grid gap-6 lg:grid-cols-3">
+        <Card className="lg:col-span-2">
+          <div className="grid gap-x-4 sm:grid-cols-2">
+            <div className="relative flex flex-col">
+              <h3 className="absolute left-0 top-0 z-10 text-sm font-medium text-muted">擊球落點（藍低→紅高，{disc?.spray.length ?? 0} 球）</h3>
+              {disc && disc.spray.length > 0 ? <div className="mt-auto mb-[13%]"><SprayChart points={disc.spray} /></div>
+                : <p className="py-12 text-center text-sm text-faint">{disc === null ? "載入中…" : "無擊球追蹤資料"}</p>}
             </div>
-          )}
+            <div className="relative">
+              <h3 className="absolute left-0 top-0 z-10 text-sm font-medium text-muted">進壘點（紅揮空/藍揮棒/灰未揮，{disc?.points.length ?? 0} 球）</h3>
+              {disc && disc.points.length > 0 ? <ZoneScatter points={disc.points} />
+                : <p className="py-12 text-center text-sm text-faint">{disc === null ? "載入中…" : "無逐球資料"}</p>}
+            </div>
+          </div>
         </Card>
+        <div className="flex flex-col gap-6">
+          <Card>
+            <h3 className="mb-3 text-sm font-medium text-muted">好球帶紀律</h3>
+            {disc && disc.summary.swing_pct != null ? (
+              <div className="space-y-2">
+                {([["揮棒%", "swing_pct"], ["揮空%", "whiff_pct"], ["接觸%", "contact_pct"],
+                   ["CSW%", "csw_pct"], ["追打%（近似）", "chase_pct"], ["好球帶%（近似）", "zone_pct"]] as const)
+                  .filter(([, k]) => disc.summary[k] != null)
+                  .map(([label, k]) => (
+                    <div key={k} className="flex items-center justify-between border-b border-line pb-1.5 text-xs last:border-0">
+                      <span className="text-muted">{label}</span>
+                      <span className="font-mono tabular-nums text-ink">{disc.summary[k]}%</span>
+                    </div>
+                  ))}
+              </div>
+            ) : <p className="py-12 text-center text-sm text-faint">{disc === null ? "載入中…" : "無逐球資料"}</p>}
+          </Card>
+          <Card>
+            <h3 className="mb-3 text-sm font-medium text-muted">球種應對（{role === "batting" ? "面對" : "配球"}）</h3>
+            {arsenal === null ? <p className="py-6 text-center text-sm text-faint">載入中…</p>
+              : arsenal.length === 0 ? <p className="py-6 text-center text-sm text-faint">無逐球資料</p>
+              : <ArsenalTable items={arsenal} role={role} />}
+          </Card>
+        </div>
       </section>
 
       {/* 範圍切換 + 逐月趨勢 */}
@@ -292,10 +317,9 @@ export default function PlayerPage() {
             </div>
           )}
         </div>
-        <div className="grid gap-6 lg:grid-cols-2">
         <Card>
           <div className="mb-3 flex items-center justify-between gap-3">
-            <h3 className="text-sm font-medium text-muted">逐月趨勢</h3>
+            <h3 className="text-sm font-medium text-muted">{scope === "season" ? "賽季走勢（逐場累積）" : "逐月趨勢"}</h3>
             <select value={monthMetric} onChange={(e) => setMonthMetric(e.target.value)}
               className="rounded-md border border-line bg-surface px-2 py-1 text-xs text-ink outline-none focus:border-ink">
               {metrics.map((m) => <option key={m.key} value={m.key}>{m.label}</option>)}
@@ -305,22 +329,16 @@ export default function PlayerPage() {
             <ResponsiveContainer width="100%" height={220}>
               <LineChart data={monthData} margin={{ top: 5, right: 10, left: -10, bottom: 0 }}>
                 <CartesianGrid stroke="#eef2f7" />
-                <XAxis dataKey="name" {...axis} />
+                <XAxis dataKey="name" {...axis} minTickGap={28} />
                 <YAxis {...axis} domain={["auto", "auto"]} />
                 <Tooltip contentStyle={{ background: "#fff", border: "1px solid #e2e8f0", borderRadius: 8, fontSize: 12 }}
                   formatter={(v: number) => v?.toFixed(metric.dp)} />
-                <Line type="monotone" dataKey="v" name={metric.label} stroke="#0a2540" strokeWidth={2} dot={{ r: 3, fill: "#d62839" }} />
+                <Line type="monotone" dataKey="v" name={metric.label} stroke="#0a2540" strokeWidth={2}
+                  dot={monthData.length > 18 ? false : { r: 3, fill: "#d62839" }} />
               </LineChart>
             </ResponsiveContainer>
           )}
         </Card>
-        <Card>
-          <h3 className="mb-3 text-sm font-medium text-muted">球種應對（{role === "batting" ? "面對" : "配球"}；速球/變化球）</h3>
-          {arsenal === null ? <p className="py-8 text-center text-sm text-faint">載入中…</p>
-            : arsenal.length === 0 ? <p className="py-8 text-center text-sm text-faint">無逐球資料</p>
-            : <ArsenalTable items={arsenal} role={role} />}
-        </Card>
-        </div>
       </section>
 
       {/* 分項明細 */}

--- a/web/src/components/spray-chart.tsx
+++ b/web/src/components/spray-chart.tsx
@@ -1,27 +1,28 @@
-// 擊球落點圖（SVG）：用 TrackMan bearing(方向)＋distance(距離)。本壘在底部中央，
-// 球場向上扇形展開；點以擊球初速著色（藍↔紅）。
+// 擊球落點圖（SVG）：用 TrackMan bearing(方向)＋distance(距離)。本壘貼底部中央
+// （本壘後側為界外/死球區，不留空間），球場向上扇形展開；點以擊球初速著色（藍↔紅）。
+// 全壘打牆畫在 ~118m，縮放上限取 135m → 越牆全壘打仍能畫在牆弧上方。
 import { prColor } from "@/components/ui";
 
 export type SprayPoint = { dir: number; dist: number; ev: number | null };
 
 export function SprayChart({ points, evMin = 100, evMax = 175 }: { points: SprayPoint[]; evMin?: number; evMax?: number }) {
-  const W = 300, H = 215, cx = W / 2, baseY = H - 14;
-  const maxDist = 130; // m
-  const scale = (H - 40) / maxDist;
-  const foul = 45 * (Math.PI / 180);
+  const W = 300, H = 232, cx = W / 2, baseY = H - 6; // 本壘貼底
+  const fenceDist = 118;  // 全壘打牆（畫弧）
+  const maxDist = 135;    // 縮放上限，保留牆外長打空間
+  const scale = (baseY - 8) / maxDist;
   const pt = (deg: number, dist: number) => {
     const r = (deg * Math.PI) / 180;
     return [cx + dist * scale * Math.sin(r), baseY - dist * scale * Math.cos(r)] as const;
   };
-  const [lfx, lfy] = pt(-foul * (180 / Math.PI), maxDist);
-  const [rfx, rfy] = pt(foul * (180 / Math.PI), maxDist);
+  const [lfx, lfy] = pt(-45, fenceDist);
+  const [rfx, rfy] = pt(45, fenceDist);
   const evColor = (ev: number | null) =>
     ev == null ? "#94a3b8" : prColor(Math.max(0, Math.min(100, ((ev - evMin) / (evMax - evMin)) * 100)));
 
   return (
     <svg viewBox={`0 0 ${W} ${H}`} className="w-full">
-      {/* 外野弧 */}
-      <path d={`M ${lfx} ${lfy} A ${maxDist * scale} ${maxDist * scale} 0 0 1 ${rfx} ${rfy}`}
+      {/* 外野（全壘打牆）弧 */}
+      <path d={`M ${lfx} ${lfy} A ${fenceDist * scale} ${fenceDist * scale} 0 0 1 ${rfx} ${rfy}`}
         fill="#eef2f7" stroke="#cbd5e1" strokeWidth={1} />
       {/* 邊線 */}
       <line x1={cx} y1={baseY} x2={lfx} y2={lfy} stroke="#cbd5e1" strokeWidth={1} />
@@ -35,7 +36,7 @@ export function SprayChart({ points, evMin = 100, evMax = 175 }: { points: Spray
       })()}
       {points.map((p, i) => {
         const [x, y] = pt(p.dir, p.dist);
-        return <circle key={i} cx={x} cy={y} r={3} fill={evColor(p.ev)} fillOpacity={0.8} />;
+        return <circle key={i} cx={x} cy={y} r={3.6} fill={evColor(p.ev)} fillOpacity={0.8} />;
       })}
       <text x={10} y={H - 4} className="fill-faint" fontSize={10}>左外野</text>
       <text x={W - 42} y={H - 4} className="fill-faint" fontSize={10}>右外野</text>

--- a/web/src/components/zone-scatter.tsx
+++ b/web/src/components/zone-scatter.tsx
@@ -2,8 +2,9 @@
 export type ZonePoint = { x: number; y: number; sw: boolean; wh: boolean };
 
 export function ZoneScatter({ points }: { points: ZonePoint[] }) {
-  const W = 230, H = 215, pad = 14;
-  const xMin = -0.8, xMax = 0.8, yMin = -0.2, yMax = 1.7;
+  // 視野收緊到好球帶周邊（±0.62、0.0–1.55）：太邊角的球參考價值低，超界點由 svg 自動裁切。
+  const W = 230, H = 240, pad = 12;
+  const xMin = -0.62, xMax = 0.62, yMin = 0.0, yMax = 1.55;
   const sx = (x: number) => pad + ((x - xMin) / (xMax - xMin)) * (W - 2 * pad);
   const sy = (y: number) => H - pad - ((y - yMin) / (yMax - yMin)) * (H - 2 * pad);
   // 好球帶（校準值 side±0.21、高 0.5–1.0）
@@ -21,7 +22,7 @@ export function ZoneScatter({ points }: { points: ZonePoint[] }) {
         </g>
       ))}
       {points.map((p, i) => (
-        <circle key={i} cx={sx(p.x)} cy={sy(p.y)} r={2.6}
+        <circle key={i} cx={sx(p.x)} cy={sy(p.y)} r={3.4}
           fill={p.wh ? "#d62839" : p.sw ? "#1d6fb8" : "#cbd5e1"}
           fillOpacity={p.sw ? 0.85 : 0.5} />
       ))}

--- a/web/src/lib/client.ts
+++ b/web/src/lib/client.ts
@@ -130,6 +130,8 @@ export const detail = {
     clientGet<{ batting: StatRow | null; pitching: StatRow | null }>(`/api/v1/players/${id}/season`),
   arsenal: (id: string, role: "batting" | "pitching") =>
     clientGet<{ items: StatRow[] }>(`/api/v1/players/${id}/arsenal?role=${role}`),
+  trend: (id: string, role: "batting" | "pitching") =>
+    clientGet<{ items: StatRow[] }>(`/api/v1/players/${id}/trend?role=${role}`),
   advanced: (id: string) =>
     clientGet<{ batting: StatRow | null; pitching: StatRow | null }>(`/api/v1/players/${id}/advanced`),
   discipline: (id: string, role: "batting" | "pitching") =>


### PR DESCRIPTION
## 摘要
- API:新增 `/players/{id}/arsenal`(球種應對)與 `/players/{id}/trend`(逐場累積季成績)端點。
- Web 球員頁版面重整:
  - 趨勢圖改逐場累積(~50 點,隨賽季收斂),全寬呈現;投手加 WHIP。
  - 擊球落點/進壘點放大、裁外圍邊角、本壘貼底保留越牆全壘打、底線與二壘對齊好球帶下緣。
  - 好球帶紀律 + 球種應對 併入右欄;內文字級統一比照 PR 表。

## 驗證
- `uv run ruff check` 通過;`npx tsc --noEmit` 通過;球員頁本機 200。
- Playwright 量測:二壘與好球帶下緣螢幕 y 對齊(diff 0px)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)