### PR TITLE
feat: catcher fielding stats (阻殺/捕逸) + pitcher wild pitches

### DIFF
--- a/migrations/021_fielding_catcher.sql
+++ b/migrations/021_fielding_catcher.sql
@@ -1,0 +1,6 @@
+-- 守備補欄：官網守備表（teamscore position=03）其實含 12 欄，原爬蟲只取 7 欄，
+-- 丟棄了三殺/捕逸/盜壘阻殺(阻殺)/被盜成功。補進這些（捕手關鍵守備指標）。
+ALTER TABLE cpbl.fielding_current ADD COLUMN IF NOT EXISTS tp  int;  -- 三殺 triple play
+ALTER TABLE cpbl.fielding_current ADD COLUMN IF NOT EXISTS pb  int;  -- 捕逸 passed ball
+ALTER TABLE cpbl.fielding_current ADD COLUMN IF NOT EXISTS cs  int;  -- 盜壘阻殺 caught stealing
+ALTER TABLE cpbl.fielding_current ADD COLUMN IF NOT EXISTS sba int;  -- 被盜成功 stolen bases allowed

--- a/scripts/refresh-cpbl-prod.sh
+++ b/scripts/refresh-cpbl-prod.sh
@@ -65,7 +65,7 @@ sync_table pitching_current "year,player_id" name team_code era ip g gs w l whip
   so cg sho pa np h hr bb ibb hbp wp bk r er go ao goao
 sync_table batting_current "year,player_id" name team_code pa avg obp slg ops hr ops_plus k_pct bb_pct \
   g ab r h b2 b3 rbi bb so sb cs tb gidp sh sf ibb hbp go ao goao
-sync_table fielding_current "year,player_id,pos" name team_code g tc po a e dp fpct
+sync_table fielding_current "year,player_id,pos" name team_code g tc po a e dp tp pb cs sba fpct
 sync_table team_current "year,team_code" name bat_avg bat_obp bat_slg bat_ops bat_hr pit_era pit_whip
 sync_table team_standings "year,kind_code,season_code,team_code" \
   team_name rank g w t l win_pct gb elim home_record away_record streak last10 h2h

--- a/src/cpbl/api/main.py
+++ b/src/cpbl/api/main.py
@@ -599,7 +599,7 @@ def player_fielding(player_id: str, season: int = Query(DEFAULT_SEASON)) -> dict
         cur = c.cursor()
         cur.execute(
             """
-            SELECT pos, g, tc, po, a, e, dp, fpct
+            SELECT pos, g, tc, po, a, e, dp, tp, pb, cs, sba, fpct
             FROM cpbl.fielding_current
             WHERE player_id = %s AND year = %s
             ORDER BY g DESC NULLS LAST, tc DESC NULLS LAST
@@ -608,8 +608,9 @@ def player_fielding(player_id: str, season: int = Query(DEFAULT_SEASON)) -> dict
         )
         items = [
             {"pos": pos, "g": g, "tc": tc, "po": po, "a": a, "e": e, "dp": dp,
+             "tp": tp, "pb": pb, "cs": cs, "sba": sba,
              "fpct": float(fpct) if fpct is not None else None}
-            for pos, g, tc, po, a, e, dp, fpct in cur.fetchall()
+            for pos, g, tc, po, a, e, dp, tp, pb, cs, sba, fpct in cur.fetchall()
         ]
     return {"player_id": player_id, "season": season, "items": items}
 

--- a/src/cpbl/ingest/cpbl_stats.py
+++ b/src/cpbl/ingest/cpbl_stats.py
@@ -247,11 +247,14 @@ def fetch_fielding(year: int, kind_code: str = "A") -> list[tuple]:
                 if len(nums) < 12 or not nums[0]:
                     continue
                 name_m = re.search(r'/team/person\?acnt=\d+"[^>]*>([^<]+)</a>', tr)
+                # 欄序：守位 出賽 守備機會 刺殺 助殺 失誤 雙殺 三殺 捕逸 盜壘阻殺 被盜成功 守備率
                 rows.append((
                     year, mid.group(1), name_m.group(1).strip() if name_m else None, team_code,
                     nums[0],
                     _int(_num(nums[1])), _int(_num(nums[2])), _int(_num(nums[3])),
-                    _int(_num(nums[4])), _int(_num(nums[5])), _int(_num(nums[6])), _num(nums[11]),
+                    _int(_num(nums[4])), _int(_num(nums[5])), _int(_num(nums[6])),
+                    _int(_num(nums[7])), _int(_num(nums[8])), _int(_num(nums[9])), _int(_num(nums[10])),
+                    _num(nums[11]),
                 ))
     finally:
         client.close()
@@ -263,11 +266,12 @@ def upsert_fielding(records: list[tuple]) -> int:
         c.cursor().executemany(
             """
             INSERT INTO cpbl.fielding_current
-                (year, player_id, name, team_code, pos, g, tc, po, a, e, dp, fpct)
-            VALUES (%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s)
+                (year, player_id, name, team_code, pos, g, tc, po, a, e, dp, tp, pb, cs, sba, fpct)
+            VALUES (%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s)
             ON CONFLICT (year, player_id, pos) DO UPDATE SET
                 name=EXCLUDED.name, team_code=EXCLUDED.team_code, g=EXCLUDED.g, tc=EXCLUDED.tc,
-                po=EXCLUDED.po, a=EXCLUDED.a, e=EXCLUDED.e, dp=EXCLUDED.dp, fpct=EXCLUDED.fpct
+                po=EXCLUDED.po, a=EXCLUDED.a, e=EXCLUDED.e, dp=EXCLUDED.dp,
+                tp=EXCLUDED.tp, pb=EXCLUDED.pb, cs=EXCLUDED.cs, sba=EXCLUDED.sba, fpct=EXCLUDED.fpct
             """,
             records,
         )

--- a/web/src/app/players/[id]/page.tsx
+++ b/web/src/app/players/[id]/page.tsx
@@ -238,7 +238,8 @@ export default function PlayerPage() {
                    ["先發", String(s.gs ?? "—"), false], ["三振", String(s.so ?? "—"), true],
                    ["K9", numOf(s.k9)?.toFixed(2) ?? "—", false], ["被安", String(s.h ?? "—"), false],
                    ["被轟", String(s.hr ?? "—"), false], ["四壞", String(s.bb ?? "—"), false],
-                   ["失分", String(s.r ?? "—"), false], ["自責", String(s.er ?? "—"), false], ["出賽", String(s.g ?? "—"), false]]
+                   ["暴投", String(s.wp ?? "—"), false], ["失分", String(s.r ?? "—"), false],
+                   ["自責", String(s.er ?? "—"), false], ["出賽", String(s.g ?? "—"), false]]
               ).map(([l, v, a]) => <StatTile key={l as string} label={l as string} value={v as string} accent={a as boolean} />)}
             </div>
           ) : <p className="text-sm text-muted">本季無{role === "batting" ? "打擊" : "投球"}成績。</p>}
@@ -348,38 +349,50 @@ export default function PlayerPage() {
       </section>
 
       {/* 守備 */}
-      {fielding && fielding.length > 0 && (
-        <section className="mb-6">
-          <h2 className="mb-3 text-lg font-semibold text-ink">守備</h2>
-          <div className="overflow-x-auto rounded-xl border border-line bg-surface">
-            <table className="w-full text-sm">
-              <thead className="bg-surface-2 text-left text-muted">
-                <tr>
-                  {([["守位", "守備位置"], ["出賽", "該守位出賽場數 G"], ["守備機會", "TC＝刺殺＋助殺＋失誤"],
-                     ["刺殺", "PO：直接使打者/跑者出局"], ["助殺", "A：傳球協助使對方出局"], ["失誤", "E"],
-                     ["雙殺", "參與的雙殺次數"], ["守備率", "(刺殺＋助殺) ÷ 守備機會"]] as const).map(([h, tip], i) => (
-                    <th key={h} title={tip} className={`cursor-help px-3 py-2 font-medium ${i === 0 ? "" : "text-right"}`}>{h}</th>
-                  ))}
-                </tr>
-              </thead>
-              <tbody className="font-mono tabular-nums">
-                {fielding.map((r) => (
-                  <tr key={String(r.pos)} className="border-t border-line">
-                    <td className="px-3 py-2 font-sans text-ink">{String(r.pos)}</td>
-                    <td className="px-3 py-2 text-right text-muted">{n0(r.g)}</td>
-                    <td className="px-3 py-2 text-right">{n0(r.tc)}</td>
-                    <td className="px-3 py-2 text-right">{n0(r.po)}</td>
-                    <td className="px-3 py-2 text-right">{n0(r.a)}</td>
-                    <td className="px-3 py-2 text-right text-accent">{n0(r.e)}</td>
-                    <td className="px-3 py-2 text-right">{n0(r.dp)}</td>
-                    <td className="px-3 py-2 text-right text-ink">{r.fpct == null ? "—" : Number(r.fpct).toFixed(3).replace(/^0\./, ".")}</td>
+      {fielding && fielding.length > 0 && (() => {
+        const hasC = fielding.some((r) => String(r.pos).includes("捕") || numOf(r.cs) || numOf(r.pb) || numOf(r.sba));
+        const cols: { key: string; label: string; tip: string; tone?: string; catcher?: boolean }[] = [
+          { key: "g", label: "出賽", tip: "該守位出賽場數 G", tone: "text-muted" },
+          { key: "tc", label: "守備機會", tip: "TC＝刺殺＋助殺＋失誤" },
+          { key: "po", label: "刺殺", tip: "PO：直接使打者/跑者出局" },
+          { key: "a", label: "助殺", tip: "A：傳球協助使對方出局" },
+          { key: "e", label: "失誤", tip: "E", tone: "text-accent" },
+          { key: "dp", label: "雙殺", tip: "參與的雙殺次數" },
+          { key: "tp", label: "三殺", tip: "參與的三殺次數" },
+          { key: "pb", label: "捕逸", tip: "PB：捕手漏接致跑者進壘", catcher: true },
+          { key: "cs", label: "盜壘阻殺", tip: "阻殺：捕手傳殺盜壘跑者", catcher: true },
+          { key: "sba", label: "被盜成功", tip: "被盜壘成功數", catcher: true },
+        ].filter((c) => !c.catcher || hasC);
+        return (
+          <section className="mb-6">
+            <h2 className="mb-3 text-lg font-semibold text-ink">守備</h2>
+            <div className="overflow-x-auto rounded-xl border border-line bg-surface">
+              <table className="w-full text-sm">
+                <thead className="bg-surface-2 text-left text-muted">
+                  <tr>
+                    <th className="px-3 py-2 font-medium">守位</th>
+                    {cols.map((c) => (
+                      <th key={c.key} title={c.tip} className="cursor-help px-3 py-2 text-right font-medium">{c.label}</th>
+                    ))}
+                    <th title="(刺殺＋助殺) ÷ 守備機會" className="cursor-help px-3 py-2 text-right font-medium">守備率</th>
                   </tr>
-                ))}
-              </tbody>
-            </table>
-          </div>
-        </section>
-      )}
+                </thead>
+                <tbody className="font-mono tabular-nums">
+                  {fielding.map((r) => (
+                    <tr key={String(r.pos)} className="border-t border-line">
+                      <td className="px-3 py-2 font-sans text-ink">{String(r.pos)}</td>
+                      {cols.map((c) => (
+                        <td key={c.key} className={`px-3 py-2 text-right ${c.tone ?? ""}`}>{n0(r[c.key])}</td>
+                      ))}
+                      <td className="px-3 py-2 text-right text-ink">{r.fpct == null ? "—" : Number(r.fpct).toFixed(3).replace(/^0\./, ".")}</td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          </section>
+        );
+      })()}
 
       {/* 分項明細 */}
       <section className="mb-6">


### PR DESCRIPTION
守備表原本丟棄官網的三殺/捕逸/盜壘阻殺(阻殺)/被盜成功 → 補爬蟲解析 + migration 021 + endpoint + 前端(捕手列才顯示捕手專屬欄)。投手本季成績補上暴投(wp)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)