### PR TITLE
fix: keep all ballparks in splits + splits 本季/生涯 toggle

### DIFF
--- a/migrations/022_splits_pk_itemname.sql
+++ b/migrations/022_splits_pk_itemname.sql
@@ -1,0 +1,31 @@
+-- 分項主鍵修正：官網「球場」分組所有列的 ItemIndex 都是 1，與舊主鍵
+-- (year,kind_code,acnt,item_group_code,item_index) 衝突 → 9 個球場被 UPSERT 蓋成 1 筆。
+-- 修法：把 item_name 加進主鍵（與 item_index 並存，6 欄）。球場 index 同、name 異 → 唯一；
+-- 局數等空名列 name 同、index 異 → 唯一。新主鍵是舊主鍵的超集，既有資料必然不衝突。
+-- 冪等：僅當主鍵尚未含 item_name 時才換。
+UPDATE cpbl.batting_splits  SET item_name = '' WHERE item_name IS NULL;
+UPDATE cpbl.pitching_splits SET item_name = '' WHERE item_name IS NULL;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint c
+    JOIN pg_attribute a ON a.attrelid = c.conrelid AND a.attnum = ANY (c.conkey)
+    WHERE c.conrelid = 'cpbl.batting_splits'::regclass AND c.contype = 'p' AND a.attname = 'item_name'
+  ) THEN
+    ALTER TABLE cpbl.batting_splits ALTER COLUMN item_name SET NOT NULL;
+    ALTER TABLE cpbl.batting_splits DROP CONSTRAINT IF EXISTS batting_splits_pkey;
+    ALTER TABLE cpbl.batting_splits
+      ADD CONSTRAINT batting_splits_pkey PRIMARY KEY (year, kind_code, acnt, item_group_code, item_index, item_name);
+  END IF;
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint c
+    JOIN pg_attribute a ON a.attrelid = c.conrelid AND a.attnum = ANY (c.conkey)
+    WHERE c.conrelid = 'cpbl.pitching_splits'::regclass AND c.contype = 'p' AND a.attname = 'item_name'
+  ) THEN
+    ALTER TABLE cpbl.pitching_splits ALTER COLUMN item_name SET NOT NULL;
+    ALTER TABLE cpbl.pitching_splits DROP CONSTRAINT IF EXISTS pitching_splits_pkey;
+    ALTER TABLE cpbl.pitching_splits
+      ADD CONSTRAINT pitching_splits_pkey PRIMARY KEY (year, kind_code, acnt, item_group_code, item_index, item_name);
+  END IF;
+END $$;

--- a/scripts/refresh-cpbl-prod.sh
+++ b/scripts/refresh-cpbl-prod.sh
@@ -82,11 +82,11 @@ if [ -n "${WITH_DETAIL:-}" ]; then
     fight_team_name team_no total_games starts closes complete_games shutouts wins loses save_ok save_fail \
     holds inning_pitched_cnt inning_pitched_div3 whip era plate_appearances pitch_cnt hits home_runs bb ibb \
     hbp so wild_pitch balk runs earned_runs
-  sync_table batting_splits "year,kind_code,acnt,item_group_code,item_index" \
-    item_name item_note plate_appearances at_bats hits rbi singles doubles triples home_runs total_bases \
+  sync_table batting_splits "year,kind_code,acnt,item_group_code,item_index,item_name" \
+    item_note plate_appearances at_bats hits rbi singles doubles triples home_runs total_bases \
     sac_hit sac_fly bb ibb hbp so ground_outs fly_outs goao avg obp slg ops
-  sync_table pitching_splits "year,kind_code,acnt,item_group_code,item_index" \
-    item_name item_note wins loses starts complete_games shutouts save_ok inning_pitched_cnt \
+  sync_table pitching_splits "year,kind_code,acnt,item_group_code,item_index,item_name" \
+    item_note wins loses starts complete_games shutouts save_ok inning_pitched_cnt \
     inning_pitched_div3 plate_appearances pitch_cnt strikes balls hits home_runs sac_hit sac_fly bb ibb \
     hbp so wild_pitch balk runs earned_runs
   sync_table game_scoreboard "year,kind_code,game_sno,team_no,inning_seq" \

--- a/src/cpbl/ingest/cpbl_player_detail.py
+++ b/src/cpbl/ingest/cpbl_player_detail.py
@@ -125,7 +125,7 @@ _PVT_COLS = ("year,kind_code,acnt,fight_team_code,fight_team_name,team_no,total_
 def _bsplit_rec(g: dict, year: int, kind: str) -> tuple:
     return (
         year, kind, g.get("HitterAcnt"), g.get("ItemGroupCode"), _i(g.get("ItemIndex")),
-        g.get("ItemName"), g.get("ItemNote"),
+        g.get("ItemName") or "", g.get("ItemNote"),
         _i(g.get("PlateAppearances")), _i(g.get("HitCnt")), _i(g.get("HittingCnt")),
         _i(g.get("RunBattedINCnt")), _i(g.get("OneBaseHitCnt")), _i(g.get("TwoBaseHitCnt")),
         _i(g.get("ThreeBaseHitCnt")), _i(g.get("HomeRunCnt")), _i(g.get("TotalBases")),
@@ -144,7 +144,7 @@ _BSPLIT_COLS = ("year,kind_code,acnt,item_group_code,item_index,item_name,item_n
 def _psplit_rec(g: dict, year: int, kind: str) -> tuple:
     return (
         year, kind, g.get("PitcherAcnt"), g.get("ItemGroupCode"), _i(g.get("ItemIndex")),
-        g.get("ItemName"), g.get("ItemNote"),
+        g.get("ItemName") or "", g.get("ItemNote"),
         _i(g.get("GameResultWCnt")), _i(g.get("GameResultLCnt")), _i(g.get("SPCnt")),
         _i(g.get("CompleteGameCnt")), _i(g.get("ShoutOutCnt")), _i(g.get("SaveOKCnt")),
         _i(g.get("InningPitchedCnt")), _i(g.get("InningPitchedDiv3Cnt")),
@@ -225,7 +225,7 @@ def scrape(delay: float = 1.2, apart_combos: list[tuple[int, str]] | None = None
                                       [_pvt_rec(g, VS_TEAM_YEAR, "A", acnt) for g in rows])
                 for y, k in apart_combos:
                     rs = s.apart(y, k, "02")
-                    out["psplit"] += _upsert("pitching_splits", _PSPLIT_COLS, 5,
+                    out["psplit"] += _upsert("pitching_splits", _PSPLIT_COLS, 6,
                                              [_psplit_rec(g, y, k) for g in rs])
             else:
                 rows = s.vs_team(VS_TEAM_YEAR, "")
@@ -233,7 +233,7 @@ def scrape(delay: float = 1.2, apart_combos: list[tuple[int, str]] | None = None
                                       [_bvt_rec(g, VS_TEAM_YEAR, "A", acnt) for g in rows])
                 for y, k in apart_combos:
                     rs = s.apart(y, k, "01")
-                    out["bsplit"] += _upsert("batting_splits", _BSPLIT_COLS, 5,
+                    out["bsplit"] += _upsert("batting_splits", _BSPLIT_COLS, 6,
                                              [_bsplit_rec(g, y, k) for g in rs])
             log.info("[%s %d/%d] acnt=%s 完成（bvt=%d pvt=%d bs=%d ps=%d）",
                      "P" if is_pitcher else "B", idx, total, acnt,

--- a/web/src/app/players/[id]/page.tsx
+++ b/web/src/app/players/[id]/page.tsx
@@ -73,7 +73,6 @@ const PIT_METRICS: Metric[] = [
   { key: "hits", label: "被安打", dp: 0, get: (r) => numOf(r.hits) },
   { key: "bb", label: "四壞", dp: 0, get: (r) => numOf(r.bb) },
 ];
-const MONTHS = ["三月", "四月", "五月", "六月", "七月", "八月", "九月", "十月", "十一月"];
 const axis = { tick: { fill: "#5b6b7a", fontSize: 12 }, stroke: "#cbd5e1" };
 
 function Tabs<T extends string>({ opts, v, set }: { opts: { v: T; label: string }[]; v: T; set: (x: T) => void }) {
@@ -240,17 +239,12 @@ export default function PlayerPage() {
     detail.splits(id, role, year, k).then((d) => setSplits(d.items)).catch(() => setSplits([]));
   }, [id, role, scope, kinds, profile]);
 
-  const byName = useMemo(() => {
-    const m: Record<string, StatRow> = {};
-    for (const r of splits ?? []) m[String(r.item_name)] = r;
-    return m;
-  }, [splits]);
   const metrics = role === "batting" ? BAT_METRICS : PIT_METRICS;
   const metric = metrics.find((m) => m.key === monthMetric) ?? metrics[0];
-  const monthData = useMemo(() => {
-    if (scope === "season") return (trend ?? []).map((r) => ({ name: String(r.name), v: metric.get(r) }));
-    return MONTHS.filter((mo) => byName[mo]).map((mo) => ({ name: mo.replace("月", ""), v: metric.get(byName[mo]) }));
-  }, [scope, trend, byName, metric]);
+  const monthData = useMemo(
+    () => (trend ?? []).map((r) => ({ name: String(r.name), v: metric.get(r) })),
+    [trend, metric],
+  );
   const prRows = useMemo(() => {
     const a = advanced ? (role === "batting" ? advanced.batting : advanced.pitching) : null;
     if (!a) return [];
@@ -413,28 +407,12 @@ export default function PlayerPage() {
         </div>
       </section>
 
-      {/* 範圍切換 + 逐月趨勢 */}
+      {/* 賽季走勢（逐場累積）+ 對戰各隊 */}
       <section className="mb-6">
-        <div className="mb-3 flex flex-wrap items-center gap-3">
-          <Tabs opts={[{ v: "season", label: "本季" }, { v: "career", label: "生涯" }]} v={scope} set={setScope} />
-          {scope === "career" && (
-            <div className="inline-flex flex-wrap gap-2">
-              {([["A", "例行賽"], ["C", "總冠軍"], ["E", "季後賽"]] as const).map(([k, label]) => {
-                const on = kinds.includes(k);
-                return (
-                  <button key={k} onClick={() => setKinds(on ? (kinds.length > 1 ? kinds.filter((x) => x !== k) : kinds) : [...kinds, k])}
-                    className={`rounded-full px-3 py-1 text-sm transition ${on ? "bg-accent text-white" : "bg-surface-2 text-muted hover:text-ink"}`}>
-                    {label}
-                  </button>
-                );
-              })}
-            </div>
-          )}
-        </div>
         <div className="grid gap-6 lg:grid-cols-2">
           <Card>
             <div className="mb-3 flex items-center justify-between gap-3">
-              <h3 className="text-sm font-medium text-muted">{scope === "season" ? "賽季走勢（逐場累積）" : "逐月趨勢"}</h3>
+              <h3 className="text-sm font-medium text-muted">賽季走勢（逐場累積）</h3>
               <select value={monthMetric} onChange={(e) => setMonthMetric(e.target.value)}
                 className="rounded-md border border-line bg-surface px-2 py-1 text-xs text-ink outline-none focus:border-ink">
                 {metrics.map((m) => <option key={m.key} value={m.key}>{m.label}</option>)}
@@ -520,7 +498,23 @@ export default function PlayerPage() {
 
       {/* 分項明細 */}
       <section className="mb-6">
-        <h2 className="mb-3 text-lg font-semibold text-ink">分項明細</h2>
+        <div className="mb-3 flex flex-wrap items-center gap-3">
+          <h2 className="text-lg font-semibold text-ink">分項明細</h2>
+          <Tabs opts={[{ v: "season", label: "本季" }, { v: "career", label: "生涯" }]} v={scope} set={setScope} />
+          {scope === "career" && (
+            <div className="inline-flex flex-wrap gap-2">
+              {([["A", "例行賽"], ["C", "總冠軍"], ["E", "季後賽"]] as const).map(([k, label]) => {
+                const on = kinds.includes(k);
+                return (
+                  <button key={k} onClick={() => setKinds(on ? (kinds.length > 1 ? kinds.filter((x) => x !== k) : kinds) : [...kinds, k])}
+                    className={`rounded-full px-3 py-1 text-xs transition ${on ? "bg-accent text-white" : "bg-surface-2 text-muted hover:text-ink"}`}>
+                    {label}
+                  </button>
+                );
+              })}
+            </div>
+          )}
+        </div>
         {!splits ? <p className="text-sm text-muted">載入中…</p>
           : splits.length === 0 ? <p className="text-sm text-muted">此範圍無分項資料。</p> : (
           <div className="overflow-x-auto rounded-xl border border-line bg-surface">


### PR DESCRIPTION
分項「球場」分組因官網 ItemIndex 全=1、與舊主鍵衝突,只留 1 球場 → 把 item_name 併入主鍵(migration 022)。前端分項區塊新增本季/生涯切換;趨勢固定為逐場累積。

🤖 Generated with [Claude Code](https://claude.com/claude-code)