### PR TITLE
feat(ingest): add advanced snapshot schema

### DIFF
--- a/docs/tasks/INGEST-ADV-RECONCILE1.md
+++ b/docs/tasks/INGEST-ADV-RECONCILE1.md
@@ -13,6 +13,10 @@
 - 拆開 player scalar leaderboard 與 per-pitch-type rows，消除 `acnt` merge overwrite。
 - 全量 fetch 寫 staging／run manifest，驗證 schema、空 ID、natural-key 重複與合理筆數後原子晉升。
 - partial daily refresh 與完整 snapshot 分開標記；API／分析只讀最後成功完整 snapshot。
+- snapshot 晉升必須在單一 transaction 內鎖定 run，驗證 `snapshot_scope='full'` 與
+  `(year, kind_code, dataset, role)` 完全相符，先將 `status` 轉為 `promoted`，再 UPSERT
+  `advanced_snapshot_state`；任一步失敗即整筆 rollback。DB composite FK 負責 immutable
+  scope／identity backstop；可變的 promoted 狀態由此 transaction contract 負責。
 - 對 2026 A/D `advanced_stats` 產出污染差異清單；備份後依官方 canonical set 修復。
 - 建立 replay-safe batch、dry-run、resume、rollback、before/after row counts 與抽樣 payload 對帳。
 
@@ -20,6 +24,9 @@
 
 - 2026 A 魔爾曼 `fastball`／`breakingball` 兩列皆存在，數值與官方 payload 一致。
 - current snapshot 的有效 acnt 集合與同一 run 官方集合一致；空 ID 被 skip 且有計數／告警。
+- 晉升後執行 pointer audit：`advanced_snapshot_state` JOIN `advanced_ingest_runs` 不得存在
+  `status <> 'promoted'`、`snapshot_scope <> 'full'` 或 scope identity 不一致的列；結果必須為 0，
+  並把查詢與 row count 留作 review／production evidence。
 - 舊錯誤列不再被 public query 讀到；不得以直接 TRUNCATE 當修復方案。
 - `ruff`、完整 pytest、route/API smoke、migration rehearsal、production backup／rollback evidence 齊全。
 - T4 跨模型家族或人工查核；production data repair 另需需求方 sign-off。

--- a/migrations/062_advanced_snapshot_schema.sql
+++ b/migrations/062_advanced_snapshot_schema.sql
@@ -1,0 +1,108 @@
+-- INGEST-ADV-EXPAND1：進階排行榜球種／聯盟維度與完整快照 provenance。
+-- 只做 additive expand；本 migration 不回填、不清資料、不切換既有 API read path。
+
+CREATE TABLE IF NOT EXISTS cpbl.advanced_ingest_runs (
+    id                  bigint GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+    year                smallint NOT NULL,
+    kind_code           text NOT NULL,
+    dataset             text NOT NULL
+                        CHECK (dataset IN (
+                            'player_stats', 'pitch_type_stats', 'league_summary'
+                        )),
+    role                text NOT NULL DEFAULT '',
+    snapshot_scope      text NOT NULL
+                        CHECK (snapshot_scope IN ('full', 'partial')),
+    status              text NOT NULL DEFAULT 'running'
+                        CHECK (status IN (
+                            'running', 'validated', 'rejected', 'promoted', 'failed'
+                        )),
+    source_endpoint     text NOT NULL,
+    source_version      text,
+    payload_hash        text,
+    schema_hash         text,
+    source_fetched_at   timestamptz NOT NULL,
+    started_at          timestamptz NOT NULL DEFAULT now(),
+    completed_at        timestamptz,
+    observed_rows       int NOT NULL DEFAULT 0 CHECK (observed_rows >= 0),
+    accepted_rows       int NOT NULL DEFAULT 0 CHECK (accepted_rows >= 0),
+    empty_id_rows       int NOT NULL DEFAULT 0 CHECK (empty_id_rows >= 0),
+    duplicate_key_rows  int NOT NULL DEFAULT 0 CHECK (duplicate_key_rows >= 0),
+    error_report        jsonb NOT NULL DEFAULT '{}'::jsonb,
+    provenance          jsonb NOT NULL DEFAULT '{}'::jsonb,
+    CHECK (accepted_rows <= observed_rows),
+    CHECK (completed_at IS NULL OR completed_at >= started_at)
+);
+
+CREATE INDEX IF NOT EXISTS idx_advanced_ingest_runs_scope
+    ON cpbl.advanced_ingest_runs
+       (year, kind_code, dataset, role, started_at DESC);
+
+-- Reconcile 階段才會原子更新此 pointer；expand 階段保持空表。
+CREATE TABLE IF NOT EXISTS cpbl.advanced_snapshot_state (
+    year                smallint NOT NULL,
+    kind_code           text NOT NULL,
+    dataset             text NOT NULL
+                        CHECK (dataset IN (
+                            'player_stats', 'pitch_type_stats', 'league_summary'
+                        )),
+    role                text NOT NULL DEFAULT '',
+    current_run_id      bigint NOT NULL REFERENCES cpbl.advanced_ingest_runs(id),
+    row_count           int NOT NULL CHECK (row_count >= 0),
+    source_fetched_at   timestamptz NOT NULL,
+    promoted_at         timestamptz NOT NULL DEFAULT now(),
+    PRIMARY KEY (year, kind_code, dataset, role)
+);
+
+CREATE TABLE IF NOT EXISTS cpbl.advanced_pitch_type_stats (
+    year                smallint NOT NULL,
+    kind_code           text NOT NULL,
+    role                text NOT NULL,
+    acnt                text NOT NULL CHECK (acnt <> ''),
+    pitch_type          text NOT NULL CHECK (pitch_type <> ''),
+    pitches             int CHECK (pitches >= 0),
+    kph                 real CHECK (kph >= 0),
+    kph_max             real CHECK (kph_max >= 0),
+    spin_rate           real CHECK (spin_rate >= 0),
+    spin_rate_max       real CHECK (spin_rate_max >= 0),
+    throws              text,
+    source_run_id       bigint NOT NULL REFERENCES cpbl.advanced_ingest_runs(id),
+    source_fetched_at   timestamptz NOT NULL,
+    last_seen_at        timestamptz NOT NULL,
+    source_payload      jsonb NOT NULL DEFAULT '{}'::jsonb,
+    updated_at          timestamptz NOT NULL DEFAULT now(),
+    PRIMARY KEY (year, kind_code, role, acnt, pitch_type),
+    CHECK (last_seen_at >= source_fetched_at)
+);
+
+CREATE INDEX IF NOT EXISTS idx_advanced_pitch_type_source_run
+    ON cpbl.advanced_pitch_type_stats (source_run_id);
+
+CREATE TABLE IF NOT EXISTS cpbl.advanced_league_summary (
+    year                smallint NOT NULL,
+    kind_code           text NOT NULL,
+    category            text NOT NULL CHECK (category <> ''),
+    pitch_type          text NOT NULL DEFAULT '',
+    metrics             jsonb NOT NULL,
+    source_run_id       bigint NOT NULL REFERENCES cpbl.advanced_ingest_runs(id),
+    source_fetched_at   timestamptz NOT NULL,
+    last_seen_at        timestamptz NOT NULL,
+    source_payload      jsonb NOT NULL DEFAULT '{}'::jsonb,
+    updated_at          timestamptz NOT NULL DEFAULT now(),
+    PRIMARY KEY (year, kind_code, category, pitch_type),
+    CHECK (last_seen_at >= source_fetched_at)
+);
+
+CREATE INDEX IF NOT EXISTS idx_advanced_league_summary_source_run
+    ON cpbl.advanced_league_summary (source_run_id);
+
+-- 既有列不猜測 provenance；RECONCILE1 會在差異對帳後填入。
+ALTER TABLE cpbl.advanced_stats
+    ADD COLUMN IF NOT EXISTS source_run_id bigint
+    REFERENCES cpbl.advanced_ingest_runs(id);
+ALTER TABLE cpbl.advanced_stats
+    ADD COLUMN IF NOT EXISTS source_fetched_at timestamptz;
+ALTER TABLE cpbl.advanced_stats
+    ADD COLUMN IF NOT EXISTS last_seen_at timestamptz;
+
+CREATE INDEX IF NOT EXISTS idx_advanced_stats_source_run
+    ON cpbl.advanced_stats (source_run_id);

--- a/migrations/062_advanced_snapshot_schema.sql
+++ b/migrations/062_advanced_snapshot_schema.sql
@@ -53,6 +53,61 @@ CREATE TABLE IF NOT EXISTS cpbl.advanced_snapshot_state (
     PRIMARY KEY (year, kind_code, dataset, role)
 );
 
+-- snapshot pointer 的 scope 與 identity 是 immutable invariant，必須由 DB 擋錯。
+-- status 是 run lifecycle state；RECONCILE1 必須在同一 transaction 將 run 設為
+-- promoted 後才更新 pointer，並以 audit query 驗證不存在非 promoted pointer。
+-- 下列 ALTER/DO 同時支援 fresh DB 與已套過 pre-review 062 的 upgrade path。
+ALTER TABLE cpbl.advanced_snapshot_state
+    ADD COLUMN IF NOT EXISTS current_run_scope text
+    GENERATED ALWAYS AS ('full'::text) STORED;
+
+DO $migration$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1 FROM pg_constraint
+        WHERE conrelid = 'cpbl.advanced_ingest_runs'::regclass
+          AND conname = 'advanced_ingest_runs_id_scope_key'
+    ) THEN
+        ALTER TABLE cpbl.advanced_ingest_runs
+            ADD CONSTRAINT advanced_ingest_runs_id_scope_key
+            UNIQUE (id, snapshot_scope);
+    END IF;
+
+    IF NOT EXISTS (
+        SELECT 1 FROM pg_constraint
+        WHERE conrelid = 'cpbl.advanced_ingest_runs'::regclass
+          AND conname = 'advanced_ingest_runs_id_identity_key'
+    ) THEN
+        ALTER TABLE cpbl.advanced_ingest_runs
+            ADD CONSTRAINT advanced_ingest_runs_id_identity_key
+            UNIQUE (id, year, kind_code, dataset, role);
+    END IF;
+
+    IF NOT EXISTS (
+        SELECT 1 FROM pg_constraint
+        WHERE conrelid = 'cpbl.advanced_snapshot_state'::regclass
+          AND conname = 'advanced_snapshot_state_full_run_fkey'
+    ) THEN
+        ALTER TABLE cpbl.advanced_snapshot_state
+            ADD CONSTRAINT advanced_snapshot_state_full_run_fkey
+            FOREIGN KEY (current_run_id, current_run_scope)
+            REFERENCES cpbl.advanced_ingest_runs (id, snapshot_scope);
+    END IF;
+
+    IF NOT EXISTS (
+        SELECT 1 FROM pg_constraint
+        WHERE conrelid = 'cpbl.advanced_snapshot_state'::regclass
+          AND conname = 'advanced_snapshot_state_run_identity_fkey'
+    ) THEN
+        ALTER TABLE cpbl.advanced_snapshot_state
+            ADD CONSTRAINT advanced_snapshot_state_run_identity_fkey
+            FOREIGN KEY (current_run_id, year, kind_code, dataset, role)
+            REFERENCES cpbl.advanced_ingest_runs
+                       (id, year, kind_code, dataset, role);
+    END IF;
+END
+$migration$;
+
 CREATE TABLE IF NOT EXISTS cpbl.advanced_pitch_type_stats (
     year                smallint NOT NULL,
     kind_code           text NOT NULL,

--- a/tests/test_advanced_snapshot_schema.py
+++ b/tests/test_advanced_snapshot_schema.py
@@ -5,9 +5,18 @@ from pathlib import Path
 
 import psycopg
 import pytest
+from psycopg import sql
 
 ROOT = Path(__file__).parents[1]
 MIGRATION = ROOT / "migrations" / "062_advanced_snapshot_schema.sql"
+
+
+def _assert_integrity_error(
+    connection: psycopg.Connection, statement: sql.SQL | str, parameters: tuple = ()
+) -> None:
+    with pytest.raises(psycopg.IntegrityError):
+        with connection.transaction():
+            connection.execute(statement, parameters)
 
 
 def test_advanced_snapshot_migration_is_additive_and_rerunnable() -> None:
@@ -24,6 +33,8 @@ def test_advanced_snapshot_migration_is_additive_and_rerunnable() -> None:
 
     assert "ADD COLUMN IF NOT EXISTS source_run_id" in sql
     assert "ADD COLUMN IF NOT EXISTS last_seen_at" in sql
+    assert "advanced_snapshot_state_full_run_fkey" in sql
+    assert "advanced_snapshot_state_run_identity_fkey" in sql
     assert "DROP TABLE" not in upper
     assert "DROP COLUMN" not in upper
     assert "TRUNCATE" not in upper
@@ -155,3 +166,195 @@ def test_advanced_snapshot_schema_contract_and_rerun_preserve_existing_rows() ->
             """
         ).fetchall()
         assert rows == [("breakingball", 758), ("fastball", 428)]
+
+        invalid_run_values = [
+            ("observed_rows", -1),
+            ("accepted_rows", -1),
+            ("empty_id_rows", -1),
+            ("duplicate_key_rows", -1),
+        ]
+        for column, value in invalid_run_values:
+            _assert_integrity_error(
+                connection,
+                sql.SQL(
+                    """
+                    INSERT INTO cpbl.advanced_ingest_runs (
+                        year, kind_code, dataset, role, snapshot_scope, status,
+                        source_endpoint, source_fetched_at, {column}
+                    ) VALUES (
+                        2026, 'A', 'player_stats', 'batting', 'full', 'running',
+                        '/leaderboards/pr-table', now(), %s
+                    )
+                    """
+                ).format(column=sql.Identifier(column)),
+                (value,),
+            )
+
+        _assert_integrity_error(
+            connection,
+            """
+            INSERT INTO cpbl.advanced_ingest_runs (
+                year, kind_code, dataset, role, snapshot_scope, status,
+                source_endpoint, source_fetched_at
+            ) VALUES (
+                2026, 'A', 'player_stats', 'batting', 'full', 'unknown',
+                '/leaderboards/pr-table', now()
+            )
+            """,
+        )
+        _assert_integrity_error(
+            connection,
+            """
+            INSERT INTO cpbl.advanced_ingest_runs (
+                year, kind_code, dataset, role, snapshot_scope, status,
+                source_endpoint, source_fetched_at, observed_rows, accepted_rows
+            ) VALUES (
+                2026, 'A', 'player_stats', 'batting', 'full', 'validated',
+                '/leaderboards/pr-table', now(), 1, 2
+            )
+            """,
+        )
+        _assert_integrity_error(
+            connection,
+            """
+            INSERT INTO cpbl.advanced_ingest_runs (
+                year, kind_code, dataset, role, snapshot_scope, status,
+                source_endpoint, source_fetched_at, started_at, completed_at
+            ) VALUES (
+                2026, 'A', 'player_stats', 'batting', 'full', 'validated',
+                '/leaderboards/pr-table', now(),
+                '2026-07-22T10:00:00Z', '2026-07-22T09:00:00Z'
+            )
+            """,
+        )
+        _assert_integrity_error(
+            connection,
+            """
+            INSERT INTO cpbl.advanced_pitch_type_stats (
+                year, kind_code, role, acnt, pitch_type, source_run_id,
+                source_fetched_at, last_seen_at
+            ) VALUES (
+                2026, 'A', 'pitching', '0000007791', 'fastball', %s,
+                '2026-07-22T10:00:00Z', '2026-07-22T09:00:00Z'
+            )
+            """,
+            (run_id,),
+        )
+
+        partial_run_id = connection.execute(
+            """
+            INSERT INTO cpbl.advanced_ingest_runs (
+                year, kind_code, dataset, role, snapshot_scope, status,
+                source_endpoint, source_fetched_at
+            ) VALUES (
+                2026, 'A', 'league_summary', '', 'partial', 'validated',
+                '/leaderboards/summary', now()
+            ) RETURNING id
+            """
+        ).fetchone()[0]
+        _assert_integrity_error(
+            connection,
+            """
+            INSERT INTO cpbl.advanced_snapshot_state (
+                year, kind_code, dataset, role, current_run_id,
+                row_count, source_fetched_at
+            ) VALUES (2026, 'A', 'league_summary', '', %s, 1, now())
+            """,
+            (partial_run_id,),
+        )
+
+        mismatched_run_id = connection.execute(
+            """
+            INSERT INTO cpbl.advanced_ingest_runs (
+                year, kind_code, dataset, role, snapshot_scope, status,
+                source_endpoint, source_fetched_at
+            ) VALUES (
+                2026, 'A', 'pitch_type_stats', 'pitching', 'full', 'promoted',
+                '/leaderboards/pitch-tracking', now()
+            ) RETURNING id
+            """
+        ).fetchone()[0]
+        _assert_integrity_error(
+            connection,
+            """
+            INSERT INTO cpbl.advanced_snapshot_state (
+                year, kind_code, dataset, role, current_run_id,
+                row_count, source_fetched_at
+            ) VALUES (1999, 'D', 'league_summary', 'batting', %s, 1, now())
+            """,
+            (mismatched_run_id,),
+        )
+
+
+@pytest.mark.skipif(
+    not os.getenv("ADV_SCHEMA_TEST_DATABASE_URL"),
+    reason="requires CARD_ID-isolated PostgreSQL",
+)
+def test_migration_upgrades_pre_review_snapshot_pointer_contract() -> None:
+    database_url = os.environ["ADV_SCHEMA_TEST_DATABASE_URL"]
+    assert database_url.rsplit("/", 1)[-1] == "cpbl_ingest_adv_expand1"
+    migrations = sorted((ROOT / "migrations").glob("*.sql"))
+
+    with psycopg.connect(database_url) as connection:
+        connection.execute("DROP SCHEMA IF EXISTS cpbl CASCADE")
+        for migration in migrations:
+            connection.execute(migration.read_text(encoding="utf-8"))
+
+        connection.execute(
+            """
+            ALTER TABLE cpbl.advanced_snapshot_state
+                DROP CONSTRAINT advanced_snapshot_state_full_run_fkey,
+                DROP CONSTRAINT advanced_snapshot_state_run_identity_fkey,
+                DROP COLUMN current_run_scope;
+            ALTER TABLE cpbl.advanced_ingest_runs
+                DROP CONSTRAINT advanced_ingest_runs_id_scope_key,
+                DROP CONSTRAINT advanced_ingest_runs_id_identity_key;
+            """
+        )
+        for _ in range(2):
+            connection.execute(MIGRATION.read_text(encoding="utf-8"))
+
+        constraints = {
+            row[0]
+            for row in connection.execute(
+                """
+                SELECT conname
+                FROM pg_constraint
+                WHERE connamespace = 'cpbl'::regnamespace
+                  AND conname IN (
+                    'advanced_ingest_runs_id_scope_key',
+                    'advanced_ingest_runs_id_identity_key',
+                    'advanced_snapshot_state_full_run_fkey',
+                    'advanced_snapshot_state_run_identity_fkey'
+                  )
+                """
+            )
+        }
+        assert constraints == {
+            "advanced_ingest_runs_id_scope_key",
+            "advanced_ingest_runs_id_identity_key",
+            "advanced_snapshot_state_full_run_fkey",
+            "advanced_snapshot_state_run_identity_fkey",
+        }
+
+        partial_run_id = connection.execute(
+            """
+            INSERT INTO cpbl.advanced_ingest_runs (
+                year, kind_code, dataset, role, snapshot_scope, status,
+                source_endpoint, source_fetched_at
+            ) VALUES (
+                2026, 'A', 'league_summary', '', 'partial', 'validated',
+                '/leaderboards/summary', now()
+            ) RETURNING id
+            """
+        ).fetchone()[0]
+        _assert_integrity_error(
+            connection,
+            """
+            INSERT INTO cpbl.advanced_snapshot_state (
+                year, kind_code, dataset, role, current_run_id,
+                row_count, source_fetched_at
+            ) VALUES (2026, 'A', 'league_summary', '', %s, 1, now())
+            """,
+            (partial_run_id,),
+        )

--- a/tests/test_advanced_snapshot_schema.py
+++ b/tests/test_advanced_snapshot_schema.py
@@ -1,0 +1,157 @@
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import psycopg
+import pytest
+
+ROOT = Path(__file__).parents[1]
+MIGRATION = ROOT / "migrations" / "062_advanced_snapshot_schema.sql"
+
+
+def test_advanced_snapshot_migration_is_additive_and_rerunnable() -> None:
+    sql = MIGRATION.read_text(encoding="utf-8")
+    upper = sql.upper()
+
+    for table in (
+        "cpbl.advanced_ingest_runs",
+        "cpbl.advanced_snapshot_state",
+        "cpbl.advanced_pitch_type_stats",
+        "cpbl.advanced_league_summary",
+    ):
+        assert f"CREATE TABLE IF NOT EXISTS {table}" in sql
+
+    assert "ADD COLUMN IF NOT EXISTS source_run_id" in sql
+    assert "ADD COLUMN IF NOT EXISTS last_seen_at" in sql
+    assert "DROP TABLE" not in upper
+    assert "DROP COLUMN" not in upper
+    assert "TRUNCATE" not in upper
+    assert "DELETE FROM" not in upper
+
+
+@pytest.mark.skipif(
+    not os.getenv("ADV_SCHEMA_TEST_DATABASE_URL"),
+    reason="requires CARD_ID-isolated PostgreSQL",
+)
+def test_advanced_snapshot_schema_contract_and_rerun_preserve_existing_rows() -> None:
+    database_url = os.environ["ADV_SCHEMA_TEST_DATABASE_URL"]
+    assert database_url.rsplit("/", 1)[-1] == "cpbl_ingest_adv_expand1"
+    migrations = sorted((ROOT / "migrations").glob("*.sql"))
+
+    with psycopg.connect(database_url) as connection:
+        connection.execute("DROP SCHEMA IF EXISTS cpbl CASCADE")
+        for _ in range(2):
+            for migration in migrations:
+                connection.execute(migration.read_text(encoding="utf-8"))
+        connection.execute(
+            """
+            INSERT INTO cpbl.advanced_stats (year, kind_code, acnt, role, metrics)
+            VALUES (2099, 'A', '0000000001', 'batting', '{"woba": 0.3}'::jsonb)
+            ON CONFLICT (year, kind_code, acnt, role) DO UPDATE
+            SET metrics = EXCLUDED.metrics
+            """
+        )
+        connection.commit()
+
+        for _ in range(2):
+            connection.execute(MIGRATION.read_text(encoding="utf-8"))
+        connection.commit()
+
+        row = connection.execute(
+            """
+            SELECT metrics, source_run_id, last_seen_at
+            FROM cpbl.advanced_stats
+            WHERE year = 2099 AND kind_code = 'A'
+              AND acnt = '0000000001' AND role = 'batting'
+            """
+        ).fetchone()
+        assert row == ({"woba": 0.3}, None, None)
+
+        primary_keys = {
+            record[0]: record[1]
+            for record in connection.execute(
+                """
+                SELECT tc.table_name,
+                       array_agg(kcu.column_name::text ORDER BY kcu.ordinal_position)
+                FROM information_schema.table_constraints tc
+                JOIN information_schema.key_column_usage kcu
+                  ON tc.constraint_name = kcu.constraint_name
+                 AND tc.constraint_schema = kcu.constraint_schema
+                WHERE tc.constraint_schema = 'cpbl'
+                  AND tc.constraint_type = 'PRIMARY KEY'
+                  AND tc.table_name IN (
+                    'advanced_pitch_type_stats', 'advanced_league_summary',
+                    'advanced_snapshot_state'
+                  )
+                GROUP BY tc.table_name
+                """
+            )
+        }
+        assert primary_keys["advanced_pitch_type_stats"] == [
+            "year", "kind_code", "role", "acnt", "pitch_type",
+        ]
+        assert primary_keys["advanced_league_summary"] == [
+            "year", "kind_code", "category", "pitch_type",
+        ]
+        assert primary_keys["advanced_snapshot_state"] == [
+            "year", "kind_code", "dataset", "role",
+        ]
+
+        indexes = {
+            record[0]
+            for record in connection.execute(
+                """
+                SELECT indexname
+                FROM pg_indexes
+                WHERE schemaname = 'cpbl'
+                  AND tablename IN (
+                    'advanced_ingest_runs', 'advanced_pitch_type_stats',
+                    'advanced_league_summary'
+                  )
+                """
+            )
+        }
+        assert {
+            "idx_advanced_ingest_runs_scope",
+            "idx_advanced_pitch_type_source_run",
+            "idx_advanced_league_summary_source_run",
+        } <= indexes
+
+        run_id = connection.execute(
+            """
+            INSERT INTO cpbl.advanced_ingest_runs (
+                year, kind_code, dataset, role, snapshot_scope, status,
+                source_endpoint, source_fetched_at, observed_rows, accepted_rows
+            ) VALUES (
+                2026, 'A', 'pitch_type_stats', 'pitching', 'full', 'validated',
+                '/leaderboards/pitch-tracking', '2026-07-22T09:00:00Z', 2, 2
+            ) RETURNING id
+            """
+        ).fetchone()[0]
+        with connection.cursor() as cursor:
+            cursor.executemany(
+                """
+                INSERT INTO cpbl.advanced_pitch_type_stats (
+                    year, kind_code, role, acnt, pitch_type, pitches, kph,
+                    spin_rate, throws, source_run_id, source_fetched_at, last_seen_at
+                ) VALUES (
+                    2026, 'A', 'pitching', '0000007790', %s, %s, %s,
+                    %s, 'R', %s, '2026-07-22T09:00:00Z', '2026-07-22T09:00:00Z'
+                )
+                """,
+                [
+                    ("breakingball", 758, 135.9062, 1977.5341, run_id),
+                    ("fastball", 428, 146.3434, 2326.9341, run_id),
+                ],
+            )
+        rows = connection.execute(
+            """
+            SELECT pitch_type, pitches
+            FROM cpbl.advanced_pitch_type_stats
+            WHERE year = 2026 AND kind_code = 'A' AND role = 'pitching'
+              AND acnt = '0000007790'
+            ORDER BY pitch_type
+            """
+        ).fetchall()
+        assert rows == [("breakingball", 758), ("fastball", 428)]


### PR DESCRIPTION
## 範圍

- 新增 `advanced_ingest_runs` 與 `advanced_snapshot_state`，支援完整/部分 run 與後續原子 snapshot 晉升
- 新增 `advanced_pitch_type_stats`，以 `(year, kind_code, role, acnt, pitch_type)` 保存球種維度
- 新增 `advanced_league_summary`，以 JSONB 保存官方聯盟基準
- `advanced_stats` 僅新增 nullable provenance 欄位；不回填、不清資料、不切 API read path

## 驗證

- TDD 紅測：migration 尚不存在時失敗
- 隔離 DB `cpbl_ingest_adv_expand1`：完整 migrations 連跑兩次，PK/index contract 與雙球種並存通過
- 既有 local DB：`062` 連跑兩次（0.10s / 0.05s），`advanced_stats` 維持 863 列，provenance 未回填
- `uv run ruff check`
- `ADV_SCHEMA_TEST_DATABASE_URL=... uv run pytest`：364 passed、1 skipped

## T4 Gate

- 需要跨模型家族或人工獨立查核
- production merge/deploy 前需完整備份、rollback rehearsal 與需求方 sign-off

Requested-by: ruanruan
Implemented-by: GPT-5@Codex