### PR TITLE
fix: enforce review and web test guards

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,3 +32,5 @@ jobs:
       - run: npm ci
       - name: Type check
         run: npx tsc --noEmit
+      - name: Contract tests
+        run: npm test

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -209,7 +209,7 @@ URL（`http://cpbl-analytics:4001/api/info`）。
    - scope：`ingest` `features` `models` `api` `infra`（可省略）
 2. **一個邏輯變更一個 commit**。
 3. **嚴禁 commit**：`.env`、`data/`、`artifacts/`、`.venv/`、credentials。
-4. push 前確認 `uv run ruff check`＋`uv run pytest` 通過（路由快照：新端點同步加 EXPECTED）、`cpbl-train` 回測未退化。
+4. push 前確認 `uv run ruff check`＋`uv run pytest`＋`cd web && npm test` 通過（路由快照：新端點同步加 EXPECTED）、`cpbl-train` 回測未退化。
 
 ---
 
@@ -217,5 +217,5 @@ URL（`http://cpbl-analytics:4001/api/info`）。
 
 - 條件不足強制反問，**嚴禁腦補**資料欄位 / 官網結構（先用 gh/WebFetch 查證）。
 - 觀點或前提有誤直接指出（例：有人要求用 opendata 做賽果預測 → 必須指出資料粒度不符）。
-- 改完跑驗證：`uv run ruff check` + `uv run pytest` + 容器內 `cpbl-train` 看回測對照表。
+- 改完跑驗證：`uv run ruff check` + `uv run pytest` + `cd web && npm test` + 容器內 `cpbl-train` 看回測對照表。
 - 涉及 LightGBM/原生相依，預設容器內執行，不在 macOS host 裝 build 依賴。

--- a/scripts/review_prompt.py
+++ b/scripts/review_prompt.py
@@ -7,7 +7,7 @@
 資料來源（零 AI 成本、永遠反映最新交接狀態）：
 - docs/control-plane/events.jsonl：該卡最新 handoff event（分支、worktree、source_sha、
   tier、db_scope、執行者交付摘要）
-- docs/tasks/<CARD_ID>.md：「驗收條件」「驗證」章節原文
+- docs/tasks/<CARD_ID>.md：標題含「驗收」「驗證」「Gate」的章節原文
 
 慣例（CONTROL_PLANE_CONTRACT.md「Review→merge 慣例」）：查核 APPROVE（零阻塞
 findings）後 Coordinator 直接 merge，結果回傳執行者，部署另由需求方確認。
@@ -42,10 +42,18 @@ def card_sections(card_id: str, wanted: tuple[str, ...]) -> str:
     keep = False
     for line in path.read_text(encoding="utf-8").splitlines():
         if line.startswith("## "):
-            keep = any(line[3:].strip().startswith(w) for w in wanted)
+            heading = line[3:].strip()
+            keep = any(token in heading for token in wanted)
         if keep:
             out.append(line)
-    return "\n".join(out).strip()
+    sections = "\n".join(out).strip()
+    if not sections:
+        print(
+            f"警告：{card_id} 找不到可錨定的驗收章節"
+            f"（標題須含：{', '.join(wanted)}）；review prompt 將退化為全文驗收。",
+            file=sys.stderr,
+        )
+    return sections
 
 
 def build_prompt(card_id: str) -> str:
@@ -55,7 +63,7 @@ def build_prompt(card_id: str) -> str:
     db_scope = ev.get("db_scope", "none")
     worktree = ev.get("worktree", "")
     wt_abs = ROOT / worktree if worktree else ROOT
-    sections = card_sections(card_id, ("驗收條件", "驗證"))
+    sections = card_sections(card_id, ("驗收", "驗證", "Gate"))
     indep = ("跨模型家族（非執行者所屬家族）或人工" if redline
              else "新 context／session 即可（不得為執行者本人）")
     db_note = {

--- a/tests/test_review_prompt.py
+++ b/tests/test_review_prompt.py
@@ -1,0 +1,50 @@
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+SCRIPT_PATH = Path(__file__).parents[1] / "scripts" / "review_prompt.py"
+SPEC = importlib.util.spec_from_file_location("review_prompt", SCRIPT_PATH)
+assert SPEC and SPEC.loader
+review_prompt = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(review_prompt)
+
+
+def _write_card(root: Path, heading: str) -> None:
+    path = root / "docs" / "tasks" / "CARD-A.md"
+    path.parent.mkdir(parents=True)
+    path.write_text(
+        f"# CARD-A\n\n## 背景\n\n背景內容\n\n## {heading}\n\n- [ ] 必須成立\n\n"
+        "## Log\n\n- 建卡\n",
+        encoding="utf-8",
+    )
+
+
+@pytest.mark.parametrize(
+    "heading",
+    ["驗收條件", "目標與驗收", "驗收", "驗收與回滾", "Gate 與驗證"],
+)
+def test_card_sections_matches_review_heading_variants(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, heading: str
+) -> None:
+    _write_card(tmp_path, heading)
+    monkeypatch.setattr(review_prompt, "ROOT", tmp_path)
+
+    sections = review_prompt.card_sections("CARD-A", ("驗收", "驗證", "Gate"))
+
+    assert f"## {heading}" in sections
+    assert "必須成立" in sections
+    assert "## Log" not in sections
+
+
+def test_card_sections_warns_when_no_review_heading(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    _write_card(tmp_path, "實作範圍")
+    monkeypatch.setattr(review_prompt, "ROOT", tmp_path)
+
+    sections = review_prompt.card_sections("CARD-A", ("驗收", "驗證", "Gate"))
+
+    assert sections == ""
+    assert "警告：CARD-A 找不到可錨定的驗收章節" in capsys.readouterr().err
+

--- a/tests/test_task_card_sections.py
+++ b/tests/test_task_card_sections.py
@@ -1,0 +1,49 @@
+import importlib.util
+import json
+from pathlib import Path
+
+ROOT = Path(__file__).parents[1]
+SCRIPT_PATH = ROOT / "scripts" / "review_prompt.py"
+SPEC = importlib.util.spec_from_file_location("review_prompt_for_lint", SCRIPT_PATH)
+assert SPEC and SPEC.loader
+review_prompt = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(review_prompt)
+
+ENFORCEMENT_EVENT_ID = "OPS-PROCESS-GUARD1-REGISTER-001"
+REVIEW_TOKENS = ("驗收", "驗證", "Gate")
+
+
+def _events() -> list[dict[str, object]]:
+    path = ROOT / "docs" / "control-plane" / "events.jsonl"
+    return [json.loads(line) for line in path.read_text(encoding="utf-8").splitlines() if line]
+
+
+def test_active_cards_with_new_lifecycle_events_have_review_sections() -> None:
+    events = _events()
+    start = next(
+        index for index, event in enumerate(events) if event["event_id"] == ENFORCEMENT_EVENT_ID
+    )
+    affected = {str(event["card_id"]) for event in events[start:]}
+    latest = {str(event["card_id"]): event for event in events}
+    active = sorted(
+        card_id for card_id in affected if latest[card_id]["delivery_status"] != "🏁完成"
+    )
+
+    missing = []
+    for card_id in active:
+        if not review_prompt.card_sections(card_id, REVIEW_TOKENS):
+            missing.append(card_id)
+
+    assert not missing, (
+        "流程守門生效後有 lifecycle event 的活卡必須包含標題含"
+        f" {REVIEW_TOKENS} 任一詞的驗收章節；缺少：{', '.join(missing)}"
+    )
+
+
+def test_ci_web_job_runs_contract_tests() -> None:
+    workflow = (ROOT / ".github" / "workflows" / "ci.yml").read_text(encoding="utf-8")
+    web_job = workflow.split("  web:\n", maxsplit=1)[1]
+
+    assert "working-directory: web" in web_job
+    assert "run: npx tsc --noEmit" in web_job
+    assert "run: npm test" in web_job


### PR DESCRIPTION
## 摘要\n\n- 放寬 review_prompt 驗收章節 matcher，fallback 時輸出 stderr 警告\n- 新增 lifecycle event 後活卡的章節 lint 與 matcher 變體測試\n- CI web job 納入 npm test，CLAUDE.md 同步驗證清單\n\n## 驗證\n\n- uv run ruff check\n- uv run pytest -q（487 passed, 3 skipped）\n- cd web && npm test（165 passed）\n- cd web && npx tsc --noEmit\n- 故意破壞 nav 契約：npm test exit 1（164/165），還原後全綠\n\nRequested-by: ruan6047\nImplemented-by: GPT-5@Codex