### PR TITLE
fix(dev): enforce WF-21 review escalation contract

### DIFF
--- a/docs/AI_WORKFLOW.md
+++ b/docs/AI_WORKFLOW.md
@@ -6,7 +6,7 @@
 ## 核心鐵律（速查）
 
 1. **變更分級 + 部署閘門**：依 canonical T0–T4 按風險、範圍、可逆性選閘門；T2 以上程式碼（A 類）每卡開分支，每卡／卡族有獨立 worktree；只有已審核合併至 `main` 的提交可部署。
-2. **實作／審核分離**：同一張卡的執行與查核須由不同經手者；查核發現缺陷以 PR review／event 留 finding，原執行者在原分支修正，查核者不得改 source branch。卡面／baseline／SHA／依賴等 preflight 失敗不建立 review、不增加 iteration；第三個可計數實質退回先進 escalation checkpoint，只有重複根因、舊 finding 未修或需求方裁定才轉 `🚨已升級`（canonical [`review-escalation.md`](../.ai-workflow/templates/review-escalation.md)）。查核結論統一用 `APPROVE | REQUEST_CHANGES`；舊的自由文字 `REJECT` 不得用於 WF-21 baseline 後新事件。
+2. **實作／審核分離**：同一張卡的執行與查核須由不同經手者；查核發現缺陷以 PR review／event 留 finding，原執行者在原分支修正，查核者不得改 source branch。卡面／baseline／SHA／依賴等 preflight 失敗不建立 review、不增加 iteration；第三個可計數實質退回先進 escalation checkpoint，只有重複根因、舊 finding 未修或需求方裁定才轉 `🚨已升級`（canonical [`review-escalation.md`](../.ai-workflow/templates/review-escalation.md)）。有效但不計數的 review 仍可閉合 finding；同 attempt finding 衝突須以 `review-correction` 裁決，epoch 切換須有需求方明示授權。查核結論統一用 `APPROVE | REQUEST_CHANGES`；舊的自由文字 `REJECT` 不得用於 WF-21 baseline 後新事件。
 3. **紅線獨立性**：安全、金流、統計／ML、資料正確性、資安部署與 production migration 一律 T4；review 必換模型家族或人工，且須附實測證據與必要 sign-off。
 4. **Discovery → Design → Plan**：T3/T4 先確認問題、證據與成功條件；使用者可見的 T3/T4 卡必過 Design Gate，純技術 T3/T4 卡必記錄 Design Gate `N/A` 理由；大型工作以 Initiative 管理 spec 基線、依賴、里程碑與變更。
 5. **聯邦式控制平面**：GitHub remote coordination 管 task、review、lease、CI；local resource lock 管 worktree／port／container；event log 是歷史，Ledger 是投影，不可各自手改。

--- a/docs/AI_WORKFLOW.md
+++ b/docs/AI_WORKFLOW.md
@@ -6,7 +6,7 @@
 ## 核心鐵律（速查）
 
 1. **變更分級 + 部署閘門**：依 canonical T0–T4 按風險、範圍、可逆性選閘門；T2 以上程式碼（A 類）每卡開分支，每卡／卡族有獨立 worktree；只有已審核合併至 `main` 的提交可部署。
-2. **實作／審核分離**：同一張卡的執行與查核須由不同經手者；查核發現缺陷以 PR review／event 留 finding，原執行者在原分支修正，查核者不得改 source branch。連續三次退回轉 `🚨已升級`。
+2. **實作／審核分離**：同一張卡的執行與查核須由不同經手者；查核發現缺陷以 PR review／event 留 finding，原執行者在原分支修正，查核者不得改 source branch。卡面／baseline／SHA／依賴等 preflight 失敗不建立 review、不增加 iteration；第三個可計數實質退回先進 escalation checkpoint，只有重複根因、舊 finding 未修或需求方裁定才轉 `🚨已升級`（canonical [`review-escalation.md`](../.ai-workflow/templates/review-escalation.md)）。查核結論統一用 `APPROVE | REQUEST_CHANGES`；舊的自由文字 `REJECT` 不得用於 WF-21 baseline 後新事件。
 3. **紅線獨立性**：安全、金流、統計／ML、資料正確性、資安部署與 production migration 一律 T4；review 必換模型家族或人工，且須附實測證據與必要 sign-off。
 4. **Discovery → Design → Plan**：T3/T4 先確認問題、證據與成功條件；使用者可見的 T3/T4 卡必過 Design Gate，純技術 T3/T4 卡必記錄 Design Gate `N/A` 理由；大型工作以 Initiative 管理 spec 基線、依賴、里程碑與變更。
 5. **聯邦式控制平面**：GitHub remote coordination 管 task、review、lease、CI；local resource lock 管 worktree／port／container；event log 是歷史，Ledger 是投影，不可各自手改。

--- a/docs/CONTROL_PLANE_CONTRACT.md
+++ b/docs/CONTROL_PLANE_CONTRACT.md
@@ -23,9 +23,12 @@
   deterministic `attempt_id`、epoch、結構化 findings 與推導後的 `counts_toward_escalation`。
   有效但不計數的 review／review-correction 仍更新 finding open set；同 attempt 的同 finding
   狀態衝突先標 pending，下一筆相關事件必須用 `review-correction` 裁決；未裁決才 fail loud，
-  合法 correction 後完整 append-only replay 必須恢復通過。withdrawn／撤銷採認須同步移除該
-  finding 的 unresolved carry、repeated-root 與「只由該 finding 支撐」之 target attempt
-  計數貢獻。epoch 只能由需求方核可事件逐一遞增，review 不得自行跳號。
+  合法 correction 後完整 append-only replay 必須恢復通過。衝突與 checkpoint 同時 pending 時
+  先允許 correction 清完衝突，再強制 checkpoint，兩閘不得互鎖。withdrawn、accepted=false
+  或 open finding 降級為不可計數時，須將它移出 open set，並同步移除 unresolved carry、
+  repeated-root 與「只由該 finding 支撐」之 target attempt 計數；resolved 未撤銷不得洗掉
+  真實歷史。root 重診斷須遷移同 finding 在該 epoch 全部 attempt 的 occurrence。epoch 只能由
+  需求方核可事件逐一遞增，review 不得自行跳號。
 - **`closes_review_round`（review 事件選填，布林）**：`false` 表示這一筆是**中繼關卡**（Design Gate、需求方本地人工審…），**本輪查核尚未結束**；缺席即視為終結本輪。卡面要求多道關卡時（例：`UX-ENTITY-LINKS2` 的「先本地人工審再交跨家族查核」），**前面各關的 review 事件必須帶 `false`**，否則 `review_prompt.py` 會判定本輪已結束而拒絕為後續關卡產生提示詞（DEV-REVIEW-PROMPT-GATE1）。
   - 判定採**存在終結本輪者即拒絕**：最新 handoff 之後只要任一筆 review 缺席本欄位或為 `true`，本輪即視為已結束。寫錯時（event log append-only 不得改寫）追加一筆更正用 review 事件：帶 `closes_review_round: false` 並以 **`corrects_event_id`**（review 事件選填，字串）指名**同輪內較早**被更正的那筆 review；被指名者的判定以更正事件的宣告為準（多次更正以最新一筆為準）。**未指名更正對象的 `false` 只代表它自己，不會重開已終局的一輪**——iteration 1 曾採「以最新一筆為準」，終局 REJECT 後追加任意 `false` 即可重開本輪、且該 REJECT 會被標成已通過的中繼關卡，查核退回修正（DEV-REVIEW-PROMPT-GATE1 iteration 1）。欄位非布林、更正對象不存在或指向自己時 `review_prompt.py` 一律 fail loud，且型別驗證涵蓋該卡每一筆 review（malformed 不得被後續事件掩蓋）。
   - 不得用 `delivery_status`、`owner` 或 `review_result` 的字面推斷此性質：實測 146 筆既有 review，最終 APPROVE 有 17 筆同樣停在 `🔍待查核`，且 owner 常寫成「（執行，交付待查核）」本身就含「查核」二字。**這個性質只由本欄位表達。**

--- a/docs/CONTROL_PLANE_CONTRACT.md
+++ b/docs/CONTROL_PLANE_CONTRACT.md
@@ -14,6 +14,13 @@
 ## Event、claim 與 WIP
 
 - event 必填 canonical §4.1 欄位與投影欄位；同一卡 `state_version` 自 1 嚴格遞增。handoff、review、handoff-accepted、merge、release 固定 `source_sha` 與 evidence。
+- WF-21 審核契約採用 [`review-escalation.md`](../.ai-workflow/templates/review-escalation.md)。於 canonical
+  合併、`review_prompt.py` 已改產生 WF-21 互斥結果後，第一筆 lifecycle event 寫
+  `contract_baseline: review-escalation-v1`；只有該行**之後**的事件套用新欄位，既有事件
+  不回填、不重新解讀。`workflow_ledger.py --check` 對 baseline 後的
+  `preflight-failed`、`review-invalid`、`review` 與 `escalation-checkpoint` fail loud；
+  review 必填 deterministic `attempt_id`、epoch、結構化 findings 與推導後的
+  `counts_toward_escalation`。
 - **`closes_review_round`（review 事件選填，布林）**：`false` 表示這一筆是**中繼關卡**（Design Gate、需求方本地人工審…），**本輪查核尚未結束**；缺席即視為終結本輪。卡面要求多道關卡時（例：`UX-ENTITY-LINKS2` 的「先本地人工審再交跨家族查核」），**前面各關的 review 事件必須帶 `false`**，否則 `review_prompt.py` 會判定本輪已結束而拒絕為後續關卡產生提示詞（DEV-REVIEW-PROMPT-GATE1）。
   - 判定採**存在終結本輪者即拒絕**：最新 handoff 之後只要任一筆 review 缺席本欄位或為 `true`，本輪即視為已結束。寫錯時（event log append-only 不得改寫）追加一筆更正用 review 事件：帶 `closes_review_round: false` 並以 **`corrects_event_id`**（review 事件選填，字串）指名**同輪內較早**被更正的那筆 review；被指名者的判定以更正事件的宣告為準（多次更正以最新一筆為準）。**未指名更正對象的 `false` 只代表它自己，不會重開已終局的一輪**——iteration 1 曾採「以最新一筆為準」，終局 REJECT 後追加任意 `false` 即可重開本輪、且該 REJECT 會被標成已通過的中繼關卡，查核退回修正（DEV-REVIEW-PROMPT-GATE1 iteration 1）。欄位非布林、更正對象不存在或指向自己時 `review_prompt.py` 一律 fail loud，且型別驗證涵蓋該卡每一筆 review（malformed 不得被後續事件掩蓋）。
   - 不得用 `delivery_status`、`owner` 或 `review_result` 的字面推斷此性質：實測 146 筆既有 review，最終 APPROVE 有 17 筆同樣停在 `🔍待查核`，且 owner 常寫成「（執行，交付待查核）」本身就含「查核」二字。**這個性質只由本欄位表達。**
@@ -59,7 +66,9 @@ canonical §2.1「實作與審核分離」不變：執行者不得查核或 merg
   `schema`／`data-migration`；或卡面標記需求方 sign-off。
 - **結果回傳原執行者**：merge 後由 Coordinator 將 merge_sha、findings 與後續待辦
   回傳原執行者；由**執行者**向需求方確認是否部署及其他後續（部署狀態轉態仍照
-  `AI_RUNBOOK.md` §7，需求方裁定）。REJECT 一律退回原執行者、原分支、iteration+1。
+  `AI_RUNBOOK.md` §7，需求方裁定）。只有 preflight 通過、查核有效且結論為
+  `REQUEST_CHANGES` 才退回原執行者、原分支並增加 iteration；`preflight-failed`、
+  `review-invalid` 與外部阻塞不消耗 iteration 或 escalation 額度。
 - **查核者重跑不得污染交付 artifact**：交付物含可重生成檔案（報告 JSON、快照）時，
   查核者重跑須以 `--out` 導向 scratch 路徑；若已覆寫，以 `git checkout -- <path>`
   還原受查版本後再繼續（受查 artifact 是已提交版本，不是重跑產物）。

--- a/docs/CONTROL_PLANE_CONTRACT.md
+++ b/docs/CONTROL_PLANE_CONTRACT.md
@@ -22,7 +22,10 @@
   `review-correction`、`escalation-epoch-change` 與 `escalation-checkpoint` fail loud；review 必填
   deterministic `attempt_id`、epoch、結構化 findings 與推導後的 `counts_toward_escalation`。
   有效但不計數的 review／review-correction 仍更新 finding open set；同 attempt 的同 finding
-  狀態衝突不得依事件順序覆寫。epoch 只能由需求方核可事件逐一遞增，review 不得自行跳號。
+  狀態衝突先標 pending，下一筆相關事件必須用 `review-correction` 裁決；未裁決才 fail loud，
+  合法 correction 後完整 append-only replay 必須恢復通過。withdrawn／撤銷採認須同步移除該
+  finding 的 unresolved carry、repeated-root 與「只由該 finding 支撐」之 target attempt
+  計數貢獻。epoch 只能由需求方核可事件逐一遞增，review 不得自行跳號。
 - **`closes_review_round`（review 事件選填，布林）**：`false` 表示這一筆是**中繼關卡**（Design Gate、需求方本地人工審…），**本輪查核尚未結束**；缺席即視為終結本輪。卡面要求多道關卡時（例：`UX-ENTITY-LINKS2` 的「先本地人工審再交跨家族查核」），**前面各關的 review 事件必須帶 `false`**，否則 `review_prompt.py` 會判定本輪已結束而拒絕為後續關卡產生提示詞（DEV-REVIEW-PROMPT-GATE1）。
   - 判定採**存在終結本輪者即拒絕**：最新 handoff 之後只要任一筆 review 缺席本欄位或為 `true`，本輪即視為已結束。寫錯時（event log append-only 不得改寫）追加一筆更正用 review 事件：帶 `closes_review_round: false` 並以 **`corrects_event_id`**（review 事件選填，字串）指名**同輪內較早**被更正的那筆 review；被指名者的判定以更正事件的宣告為準（多次更正以最新一筆為準）。**未指名更正對象的 `false` 只代表它自己，不會重開已終局的一輪**——iteration 1 曾採「以最新一筆為準」，終局 REJECT 後追加任意 `false` 即可重開本輪、且該 REJECT 會被標成已通過的中繼關卡，查核退回修正（DEV-REVIEW-PROMPT-GATE1 iteration 1）。欄位非布林、更正對象不存在或指向自己時 `review_prompt.py` 一律 fail loud，且型別驗證涵蓋該卡每一筆 review（malformed 不得被後續事件掩蓋）。
   - 不得用 `delivery_status`、`owner` 或 `review_result` 的字面推斷此性質：實測 146 筆既有 review，最終 APPROVE 有 17 筆同樣停在 `🔍待查核`，且 owner 常寫成「（執行，交付待查核）」本身就含「查核」二字。**這個性質只由本欄位表達。**

--- a/docs/CONTROL_PLANE_CONTRACT.md
+++ b/docs/CONTROL_PLANE_CONTRACT.md
@@ -15,12 +15,14 @@
 
 - event 必填 canonical §4.1 欄位與投影欄位；同一卡 `state_version` 自 1 嚴格遞增。handoff、review、handoff-accepted、merge、release 固定 `source_sha` 與 evidence。
 - WF-21 審核契約採用 [`review-escalation.md`](../.ai-workflow/templates/review-escalation.md)。於 canonical
-  合併、`review_prompt.py` 已改產生 WF-21 互斥結果後，第一筆 lifecycle event 寫
-  `contract_baseline: review-escalation-v1`；只有該行**之後**的事件套用新欄位，既有事件
-  不回填、不重新解讀。`workflow_ledger.py --check` 對 baseline 後的
-  `preflight-failed`、`review-invalid`、`review` 與 `escalation-checkpoint` fail loud；
-  review 必填 deterministic `attempt_id`、epoch、結構化 findings 與推導後的
-  `counts_toward_escalation`。
+  合併、`review_prompt.py` 已改產生 WF-21 互斥結果後，以獨立 `contract-baseline` lifecycle
+  event 寫 `contract_baseline: review-escalation-v1`；只有該行**之後**的事件套用新欄位，
+  既有事件不回填、不重新解讀。marker 只能出現一次且不得附在 review 等其他事件上。
+  `workflow_ledger.py --check` 對 baseline 後的 `preflight-failed`、`review-invalid`、`review`、
+  `review-correction`、`escalation-epoch-change` 與 `escalation-checkpoint` fail loud；review 必填
+  deterministic `attempt_id`、epoch、結構化 findings 與推導後的 `counts_toward_escalation`。
+  有效但不計數的 review／review-correction 仍更新 finding open set；同 attempt 的同 finding
+  狀態衝突不得依事件順序覆寫。epoch 只能由需求方核可事件逐一遞增，review 不得自行跳號。
 - **`closes_review_round`（review 事件選填，布林）**：`false` 表示這一筆是**中繼關卡**（Design Gate、需求方本地人工審…），**本輪查核尚未結束**；缺席即視為終結本輪。卡面要求多道關卡時（例：`UX-ENTITY-LINKS2` 的「先本地人工審再交跨家族查核」），**前面各關的 review 事件必須帶 `false`**，否則 `review_prompt.py` 會判定本輪已結束而拒絕為後續關卡產生提示詞（DEV-REVIEW-PROMPT-GATE1）。
   - 判定採**存在終結本輪者即拒絕**：最新 handoff 之後只要任一筆 review 缺席本欄位或為 `true`，本輪即視為已結束。寫錯時（event log append-only 不得改寫）追加一筆更正用 review 事件：帶 `closes_review_round: false` 並以 **`corrects_event_id`**（review 事件選填，字串）指名**同輪內較早**被更正的那筆 review；被指名者的判定以更正事件的宣告為準（多次更正以最新一筆為準）。**未指名更正對象的 `false` 只代表它自己，不會重開已終局的一輪**——iteration 1 曾採「以最新一筆為準」，終局 REJECT 後追加任意 `false` 即可重開本輪、且該 REJECT 會被標成已通過的中繼關卡，查核退回修正（DEV-REVIEW-PROMPT-GATE1 iteration 1）。欄位非布林、更正對象不存在或指向自己時 `review_prompt.py` 一律 fail loud，且型別驗證涵蓋該卡每一筆 review（malformed 不得被後續事件掩蓋）。
   - 不得用 `delivery_status`、`owner` 或 `review_result` 的字面推斷此性質：實測 146 筆既有 review，最終 APPROVE 有 17 筆同樣停在 `🔍待查核`，且 owner 常寫成「（執行，交付待查核）」本身就含「查核」二字。**這個性質只由本欄位表達。**

--- a/docs/HANDOFF_CONTRACT.md
+++ b/docs/HANDOFF_CONTRACT.md
@@ -92,8 +92,13 @@ receiver 在寫 `handoff-accepted` 前必須逐項完成，並把結果寫進該
 - **查核提示詞**：`uv run python scripts/review_prompt.py <CARD_ID>`（見 `CONTROL_PLANE_CONTRACT.md`〈交付→查核→合併慣例〉）。
 - **tmux launcher／wake-up**：不使用。
 - **Runtime 路徑與 `.gitignore`**：不適用（無本機 queue）。
-- **失敗、重試與人工介入**：拒收即寫 `⏸阻塞` 或 review REJECT，退回原執行者、原分支、`iteration + 1`；
-  連續三次退回轉 `🚨已升級`，由需求方裁定（canonical §3、§5）。
+- **失敗、重試與人工介入**：receiver acceptance／review preflight 未通過時，可由 sender／
+  Coordinator 補齊的交付缺口寫 `preflight-failed`；外部等待不屬 preflight failure，應以
+  `status-change` 轉 `⏸阻塞`。兩者都**不得**建立 review event、不得增加 iteration；
+  只有 preflight 通過後的有效實質 `REQUEST_CHANGES` 才回原執行者、原分支並 `iteration + 1`。
+  同一 escalation epoch／source SHA 的多 reviewer 最多計一次；第三個可計數 attempt 先進
+  `escalation-checkpoint`，再依重複根因、未閉合 finding 或需求方裁定決定是否 `🚨已升級`
+  （canonical §3、§5 與 [`review-escalation.md`](../.ai-workflow/templates/review-escalation.md)）。
 
 ## 6. 已知落差
 

--- a/scripts/review_prompt.py
+++ b/scripts/review_prompt.py
@@ -802,11 +802,21 @@ def build_prompt(card_id: str) -> str:
 
 ### 產出格式
 
-回覆 **APPROVE 或 REJECT**，附 findings 清單（每條含 severity／證據／建議處置）
-與你實際重跑的指令與輸出摘要。依本專案慣例：**APPROVE（零阻塞 findings）後
-Coordinator 將直接 merge** 並將結果回傳執行者，部署與後續另由需求方確認；
-REJECT 則退回原執行者於原分支修正（iteration+1）。你的結論將由需求方轉錄為
-review event（source_sha={ev.get('source_sha', '?')[:7]}）留痕。
+先分類再給結論：若是卡面／baseline／SHA／依賴／必要證據等送審前條件不成立，
+回覆 **PREFLIGHT_FAILED**（外部等待改回 **BLOCKED**），不得用 REQUEST_CHANGES；
+若查核順序、artifact、環境或獨立性使本次查核不成立，回覆 **REVIEW_INVALID**。
+只有 preflight 通過且查核有效時，才回覆 **APPROVE 或 REQUEST_CHANGES**。
+
+APPROVE／REQUEST_CHANGES 必須附結構化 findings；每條含
+`finding_id`、`severity`、`blocking`、`finding_class`、`attribution`、
+`root_cause_id`、`evidence`、`disposition`。`accepted`、`status` 與
+`counts_toward_escalation` 由 lifecycle writer 依 canonical `review-escalation.md`
+及可重現證據裁定，reviewer 不得用自由文字自行宣告。另附你實際重跑的指令與輸出摘要。
+
+依本專案慣例：**APPROVE（零未閉合 blocking findings）後 Coordinator 將直接 merge**
+並將結果回傳執行者，部署與後續另由需求方確認；REQUEST_CHANGES 才會退回原執行者
+於原分支修正並增加 iteration。你的結論將由需求方轉錄為 event
+（source_sha={ev.get('source_sha', '?')[:7]}）留痕。
 """
 
 

--- a/scripts/workflow_ledger.py
+++ b/scripts/workflow_ledger.py
@@ -22,6 +22,10 @@ FINDING_FIELDS = {
     "attribution", "root_cause_id", "evidence", "disposition",
 }
 COUNTED_FINDING_CLASSES = {"implementation", "authoritative-artifact"}
+FINDING_CONFLICT_FIELDS = {
+    "severity", "blocking", "accepted", "status", "finding_class", "attribution",
+    "root_cause_id",
+}
 
 
 def _require_fields(event: dict[str, object], fields: set[str]) -> None:
@@ -45,6 +49,32 @@ def _counted_review(event: dict[str, object]) -> bool:
     )
 
 
+def _validate_finding(event_id: object, finding: object) -> dict[str, object]:
+    if not isinstance(finding, dict):
+        raise ValueError(f"{event_id} finding 必須為物件")
+    _require_fields(finding, FINDING_FIELDS)
+    if finding["severity"] not in {"critical", "major", "minor", "info"}:
+        raise ValueError(f"{event_id} finding severity 不合法")
+    if finding["status"] not in {"open", "resolved", "withdrawn"}:
+        raise ValueError(f"{event_id} finding status 不合法")
+    if finding["finding_class"] not in {
+        "implementation", "authoritative-artifact", "governance", "coordination",
+        "environment",
+    }:
+        raise ValueError(f"{event_id} finding_class 不合法")
+    if finding["attribution"] not in {
+        "executor", "planner", "coordinator", "reviewer", "external",
+    }:
+        raise ValueError(f"{event_id} finding attribution 不合法")
+    if finding["root_cause_id"] == "unknown":
+        raise ValueError(
+            f"{event_id} unknown root_cause_id 必須加 finding-specific 識別子"
+        )
+    if not isinstance(finding["blocking"], bool) or not isinstance(finding["accepted"], bool):
+        raise ValueError(f"{event_id} finding blocking／accepted 必須為布林值")
+    return finding
+
+
 def _validate_review_event(event: dict[str, object]) -> None:
     _require_fields(event, {
         "attempt_id", "escalation_epoch", "preflight_passed", "review_result",
@@ -54,7 +84,7 @@ def _validate_review_event(event: dict[str, object]) -> None:
         raise ValueError(f"{event['event_id']} review 必須 preflight_passed=true")
     if event["review_result"] not in REVIEW_RESULTS:
         raise ValueError(f"{event['event_id']} review_result 必須為 APPROVE 或 REQUEST_CHANGES")
-    if not isinstance(event["escalation_epoch"], int) or event["escalation_epoch"] < 0:
+    if type(event["escalation_epoch"]) is not int or event["escalation_epoch"] < 0:
         raise ValueError(f"{event['event_id']} escalation_epoch 必須為非負整數")
     expected_attempt = (
         f"{event['card_id']}-e{event['escalation_epoch']}-{event['source_sha']}"
@@ -67,32 +97,11 @@ def _validate_review_event(event: dict[str, object]) -> None:
         raise ValueError(f"{event['event_id']} findings 必須為陣列")
     finding_ids: set[str] = set()
     for finding in event["findings"]:
-        if not isinstance(finding, dict):
-            raise ValueError(f"{event['event_id']} finding 必須為物件")
-        _require_fields(finding, FINDING_FIELDS)
+        finding = _validate_finding(event["event_id"], finding)
         finding_id = str(finding["finding_id"])
         if finding_id in finding_ids:
             raise ValueError(f"{event['event_id']} finding_id 重複：{finding_id}")
         finding_ids.add(finding_id)
-        if finding["severity"] not in {"critical", "major", "minor", "info"}:
-            raise ValueError(f"{event['event_id']} finding severity 不合法")
-        if finding["status"] not in {"open", "resolved", "withdrawn"}:
-            raise ValueError(f"{event['event_id']} finding status 不合法")
-        if finding["finding_class"] not in {
-            "implementation", "authoritative-artifact", "governance", "coordination",
-            "environment",
-        }:
-            raise ValueError(f"{event['event_id']} finding_class 不合法")
-        if finding["attribution"] not in {
-            "executor", "planner", "coordinator", "reviewer", "external",
-        }:
-            raise ValueError(f"{event['event_id']} finding attribution 不合法")
-        if finding["root_cause_id"] == "unknown":
-            raise ValueError(
-                f"{event['event_id']} unknown root_cause_id 必須加 finding-specific 識別子"
-            )
-        if not isinstance(finding["blocking"], bool) or not isinstance(finding["accepted"], bool):
-            raise ValueError(f"{event['event_id']} finding blocking／accepted 必須為布林值")
     if event["review_result"] == "APPROVE" and any(
         finding["accepted"] is True and finding["blocking"] is True
         and finding["status"] == "open" for finding in event["findings"]
@@ -105,6 +114,27 @@ def _validate_review_event(event: dict[str, object]) -> None:
         )
 
 
+def _apply_finding_state(
+    finding: dict[str, object], current_open: set[str],
+) -> None:
+    finding_id = str(finding["finding_id"])
+    if finding["status"] in {"resolved", "withdrawn"}:
+        current_open.discard(finding_id)
+    elif (
+        finding["accepted"] is True
+        and finding["blocking"] is True
+        and finding["finding_class"] in COUNTED_FINDING_CLASSES
+        and finding["attribution"] == "executor"
+    ):
+        current_open.add(finding_id)
+
+
+def _findings_conflict(
+    previous: dict[str, object], current: dict[str, object],
+) -> bool:
+    return any(previous[field] != current[field] for field in FINDING_CONFLICT_FIELDS)
+
+
 def _validate_review_contract(events: list[dict[str, object]]) -> None:
     """Baseline 前事件保持原貌；marker 之後 fail loud 驗證 WF-21 契約。"""
     enabled = False
@@ -113,8 +143,19 @@ def _validate_review_contract(events: list[dict[str, object]]) -> None:
     root_cause_attempts: dict[tuple[str, int], dict[str, set[str]]] = {}
     unresolved_carry: dict[tuple[str, int], bool] = {}
     pending_checkpoint: dict[str, tuple[int, int, str]] = {}
+    current_epochs: dict[str, int] = {}
+    known_attempts: dict[tuple[str, int], set[str]] = {}
+    attempt_findings: dict[tuple[str, int, str], dict[str, dict[str, object]]] = {}
     for event in events:
         if event.get("contract_baseline") == REVIEW_CONTRACT:
+            if enabled:
+                raise ValueError(
+                    f"{event['event_id']} contract_baseline={REVIEW_CONTRACT} 只能出現一次"
+                )
+            if event.get("type") != "contract-baseline":
+                raise ValueError(
+                    f"{event['event_id']} contract_baseline 只能由 contract-baseline 事件啟用"
+                )
             enabled = True
             continue
         if not enabled:
@@ -127,32 +168,101 @@ def _validate_review_contract(events: list[dict[str, object]]) -> None:
             )
         if event_type == "review":
             _validate_review_event(event)
-            if event["counts_toward_escalation"] is True:
-                key = (card_id, int(event["escalation_epoch"]))
-                attempts = counted_attempts.setdefault(key, set())
-                attempt_id = str(event["attempt_id"])
-                before = len(attempts)
-                previous_open = set(open_findings.setdefault(key, set()))
-                for finding in event["findings"]:
-                    finding_id = str(finding["finding_id"])
-                    if finding["status"] in {"resolved", "withdrawn"}:
-                        open_findings[key].discard(finding_id)
-                    elif (
-                        finding["accepted"] is True
-                        and finding["blocking"] is True
-                        and finding["finding_class"] in COUNTED_FINDING_CLASSES
-                        and finding["attribution"] == "executor"
-                    ):
-                        open_findings[key].add(finding_id)
-                        roots = root_cause_attempts.setdefault(key, {})
-                        roots.setdefault(str(finding["root_cause_id"]), set()).add(attempt_id)
-                attempts.add(attempt_id)
-                if len(attempts) > before and previous_open & open_findings[key]:
-                    unresolved_carry[key] = True
-                if len(attempts) > before and len(attempts) >= 3:
-                    pending_checkpoint[card_id] = (
-                        int(event["escalation_epoch"]), len(attempts), attempt_id,
+            epoch = int(event["escalation_epoch"])
+            expected_epoch = current_epochs.setdefault(card_id, 0)
+            if epoch != expected_epoch:
+                raise ValueError(
+                    f"{event['event_id']} escalation_epoch={epoch} 未經需求方授權；"
+                    f"目前 epoch={expected_epoch}"
+                )
+            key = (card_id, epoch)
+            attempt_id = str(event["attempt_id"])
+            known_attempts.setdefault(key, set()).add(attempt_id)
+            per_attempt = attempt_findings.setdefault((card_id, epoch, attempt_id), {})
+            for finding in event["findings"]:
+                finding_id = str(finding["finding_id"])
+                previous = per_attempt.get(finding_id)
+                if previous is not None and _findings_conflict(previous, finding):
+                    raise ValueError(
+                        f"{event['event_id']} 同一 attempt 的 finding {finding_id} 衝突；"
+                        "必須追加 correction 事件裁決"
                     )
+                per_attempt.setdefault(finding_id, finding)
+
+            attempts = counted_attempts.setdefault(key, set())
+            is_new_counted_attempt = (
+                event["counts_toward_escalation"] is True and attempt_id not in attempts
+            )
+            previous_open = set(open_findings.setdefault(key, set()))
+            for finding in event["findings"]:
+                _apply_finding_state(finding, open_findings[key])
+                if (
+                    event["counts_toward_escalation"] is True
+                    and finding["status"] == "open"
+                    and finding["accepted"] is True
+                    and finding["blocking"] is True
+                    and finding["finding_class"] in COUNTED_FINDING_CLASSES
+                    and finding["attribution"] == "executor"
+                ):
+                    roots = root_cause_attempts.setdefault(key, {})
+                    roots.setdefault(str(finding["root_cause_id"]), set()).add(attempt_id)
+            if is_new_counted_attempt:
+                attempts.add(attempt_id)
+                unresolved_carry[key] = (
+                    unresolved_carry.get(key, False)
+                    or bool(previous_open & open_findings[key])
+                )
+                if len(attempts) >= 3:
+                    pending_checkpoint[card_id] = (
+                        epoch, len(attempts), attempt_id,
+                    )
+        elif event_type == "escalation-epoch-change":
+            _require_fields(event, {
+                "from_escalation_epoch", "to_escalation_epoch", "epoch_change_reason",
+                "requester_approved",
+            })
+            current = current_epochs.setdefault(card_id, 0)
+            if (
+                event["requester_approved"] is not True
+                or type(event["from_escalation_epoch"]) is not int
+                or type(event["to_escalation_epoch"]) is not int
+                or event["epoch_change_reason"] not in {"replan", "change-executor"}
+                or event["from_escalation_epoch"] != current
+                or event["to_escalation_epoch"] != current + 1
+            ):
+                raise ValueError(
+                    f"{event['event_id']} escalation epoch 切換必須由需求方授權、"
+                    "逐一遞增，且理由為 replan 或 change-executor"
+                )
+            current_epochs[card_id] = current + 1
+        elif event_type == "review-correction":
+            _require_fields(event, {
+                "escalation_epoch", "target_attempt_id", "finding_updates",
+            })
+            epoch = event["escalation_epoch"]
+            if type(epoch) is not int or epoch != current_epochs.setdefault(card_id, 0):
+                raise ValueError(f"{event['event_id']} correction escalation_epoch 不合法")
+            key = (card_id, epoch)
+            target_attempt = str(event["target_attempt_id"])
+            updates = event["finding_updates"]
+            if target_attempt not in known_attempts.get(key, set()):
+                raise ValueError(f"{event['event_id']} correction target_attempt_id 不存在")
+            if not isinstance(updates, list) or not updates:
+                raise ValueError(f"{event['event_id']} finding_updates 必須為非空陣列")
+            target_findings = attempt_findings[(card_id, epoch, target_attempt)]
+            update_ids: set[str] = set()
+            for finding in updates:
+                finding = _validate_finding(event["event_id"], finding)
+                finding_id = str(finding["finding_id"])
+                if finding_id in update_ids:
+                    raise ValueError(f"{event['event_id']} finding_id 重複：{finding_id}")
+                update_ids.add(finding_id)
+                if finding_id not in target_findings:
+                    raise ValueError(
+                        f"{event['event_id']} correction finding_id 不存在：{finding_id}"
+                    )
+                target_findings[finding_id] = finding
+                _apply_finding_state(finding, open_findings.setdefault(key, set()))
         elif event_type == "preflight-failed":
             _require_fields(event, {"preflight_passed", "failure_reasons"})
             if event["preflight_passed"] is not False or not isinstance(
@@ -163,14 +273,24 @@ def _validate_review_contract(events: list[dict[str, object]]) -> None:
                 )
         elif event_type == "review-invalid":
             _require_fields(event, {"preflight_passed", "invalid_reasons"})
-            if not isinstance(event["invalid_reasons"], list) or not event["invalid_reasons"]:
-                raise ValueError(f"{event['event_id']} review-invalid 必須帶非空 invalid_reasons")
+            if (
+                not isinstance(event["preflight_passed"], bool)
+                or not isinstance(event["invalid_reasons"], list)
+                or not event["invalid_reasons"]
+            ):
+                raise ValueError(
+                    f"{event['event_id']} review-invalid 必須帶布林 preflight_passed "
+                    "與非空 invalid_reasons"
+                )
         elif event_type == "escalation-checkpoint":
             _require_fields(event, {
                 "escalation_epoch", "trigger_attempt_id", "unique_attempt_count",
                 "checkpoint_decision", "checkpoint_rationale",
             })
-            if not isinstance(event["unique_attempt_count"], int) or event["unique_attempt_count"] < 3:
+            if (
+                type(event["unique_attempt_count"]) is not int
+                or event["unique_attempt_count"] < 3
+            ):
                 raise ValueError(f"{event['event_id']} escalation checkpoint 至少需三個 attempt")
             if event["checkpoint_decision"] not in {
                 "continue", "replan", "change-executor", "escalate",

--- a/scripts/workflow_ledger.py
+++ b/scripts/workflow_ledger.py
@@ -15,9 +15,200 @@ REQUIRED_FIELDS = {
     "source_sha", "evidence", "initiative", "tier", "feature", "owner", "branch_worktree",
     "delivery_status", "deployment_status",
 }
+REVIEW_CONTRACT = "review-escalation-v1"
+REVIEW_RESULTS = {"APPROVE", "REQUEST_CHANGES"}
+FINDING_FIELDS = {
+    "finding_id", "severity", "blocking", "accepted", "status", "finding_class",
+    "attribution", "root_cause_id", "evidence", "disposition",
+}
+COUNTED_FINDING_CLASSES = {"implementation", "authoritative-artifact"}
+
+
+def _require_fields(event: dict[str, object], fields: set[str]) -> None:
+    missing = fields - event.keys()
+    if missing:
+        raise ValueError(
+            f"{event.get('event_id', '?')} 事件缺少欄位：{', '.join(sorted(missing))}"
+        )
+
+
+def _counted_review(event: dict[str, object]) -> bool:
+    if event["review_result"] != "REQUEST_CHANGES":
+        return False
+    return any(
+        finding["accepted"] is True
+        and finding["status"] == "open"
+        and finding["blocking"] is True
+        and finding["finding_class"] in COUNTED_FINDING_CLASSES
+        and finding["attribution"] == "executor"
+        for finding in event["findings"]
+    )
+
+
+def _validate_review_event(event: dict[str, object]) -> None:
+    _require_fields(event, {
+        "attempt_id", "escalation_epoch", "preflight_passed", "review_result",
+        "findings", "counts_toward_escalation",
+    })
+    if event["preflight_passed"] is not True:
+        raise ValueError(f"{event['event_id']} review 必須 preflight_passed=true")
+    if event["review_result"] not in REVIEW_RESULTS:
+        raise ValueError(f"{event['event_id']} review_result 必須為 APPROVE 或 REQUEST_CHANGES")
+    if not isinstance(event["escalation_epoch"], int) or event["escalation_epoch"] < 0:
+        raise ValueError(f"{event['event_id']} escalation_epoch 必須為非負整數")
+    expected_attempt = (
+        f"{event['card_id']}-e{event['escalation_epoch']}-{event['source_sha']}"
+    )
+    if event["attempt_id"] != expected_attempt:
+        raise ValueError(f"{event['event_id']} attempt_id 與 card／epoch／source_sha 不一致")
+    if not isinstance(event["source_sha"], str) or len(event["source_sha"]) != 40:
+        raise ValueError(f"{event['event_id']} source_sha 必須為完整 40 字元")
+    if not isinstance(event["findings"], list):
+        raise ValueError(f"{event['event_id']} findings 必須為陣列")
+    finding_ids: set[str] = set()
+    for finding in event["findings"]:
+        if not isinstance(finding, dict):
+            raise ValueError(f"{event['event_id']} finding 必須為物件")
+        _require_fields(finding, FINDING_FIELDS)
+        finding_id = str(finding["finding_id"])
+        if finding_id in finding_ids:
+            raise ValueError(f"{event['event_id']} finding_id 重複：{finding_id}")
+        finding_ids.add(finding_id)
+        if finding["severity"] not in {"critical", "major", "minor", "info"}:
+            raise ValueError(f"{event['event_id']} finding severity 不合法")
+        if finding["status"] not in {"open", "resolved", "withdrawn"}:
+            raise ValueError(f"{event['event_id']} finding status 不合法")
+        if finding["finding_class"] not in {
+            "implementation", "authoritative-artifact", "governance", "coordination",
+            "environment",
+        }:
+            raise ValueError(f"{event['event_id']} finding_class 不合法")
+        if finding["attribution"] not in {
+            "executor", "planner", "coordinator", "reviewer", "external",
+        }:
+            raise ValueError(f"{event['event_id']} finding attribution 不合法")
+        if finding["root_cause_id"] == "unknown":
+            raise ValueError(
+                f"{event['event_id']} unknown root_cause_id 必須加 finding-specific 識別子"
+            )
+        if not isinstance(finding["blocking"], bool) or not isinstance(finding["accepted"], bool):
+            raise ValueError(f"{event['event_id']} finding blocking／accepted 必須為布林值")
+    if event["review_result"] == "APPROVE" and any(
+        finding["accepted"] is True and finding["blocking"] is True
+        and finding["status"] == "open" for finding in event["findings"]
+    ):
+        raise ValueError(f"{event['event_id']} APPROVE 不得含未閉合 blocking finding")
+    derived = _counted_review(event)
+    if event["counts_toward_escalation"] is not derived:
+        raise ValueError(
+            f"{event['event_id']} counts_toward_escalation 必須由結構化 findings 推導為 {derived}"
+        )
+
+
+def _validate_review_contract(events: list[dict[str, object]]) -> None:
+    """Baseline 前事件保持原貌；marker 之後 fail loud 驗證 WF-21 契約。"""
+    enabled = False
+    counted_attempts: dict[tuple[str, int], set[str]] = {}
+    open_findings: dict[tuple[str, int], set[str]] = {}
+    root_cause_attempts: dict[tuple[str, int], dict[str, set[str]]] = {}
+    unresolved_carry: dict[tuple[str, int], bool] = {}
+    pending_checkpoint: dict[str, tuple[int, int, str]] = {}
+    for event in events:
+        if event.get("contract_baseline") == REVIEW_CONTRACT:
+            enabled = True
+            continue
+        if not enabled:
+            continue
+        event_type = event.get("type")
+        card_id = str(event["card_id"])
+        if card_id in pending_checkpoint and event_type != "escalation-checkpoint":
+            raise ValueError(
+                f"{event['event_id']} 前必須先為 {card_id} 寫 escalation-checkpoint"
+            )
+        if event_type == "review":
+            _validate_review_event(event)
+            if event["counts_toward_escalation"] is True:
+                key = (card_id, int(event["escalation_epoch"]))
+                attempts = counted_attempts.setdefault(key, set())
+                attempt_id = str(event["attempt_id"])
+                before = len(attempts)
+                previous_open = set(open_findings.setdefault(key, set()))
+                for finding in event["findings"]:
+                    finding_id = str(finding["finding_id"])
+                    if finding["status"] in {"resolved", "withdrawn"}:
+                        open_findings[key].discard(finding_id)
+                    elif (
+                        finding["accepted"] is True
+                        and finding["blocking"] is True
+                        and finding["finding_class"] in COUNTED_FINDING_CLASSES
+                        and finding["attribution"] == "executor"
+                    ):
+                        open_findings[key].add(finding_id)
+                        roots = root_cause_attempts.setdefault(key, {})
+                        roots.setdefault(str(finding["root_cause_id"]), set()).add(attempt_id)
+                attempts.add(attempt_id)
+                if len(attempts) > before and previous_open & open_findings[key]:
+                    unresolved_carry[key] = True
+                if len(attempts) > before and len(attempts) >= 3:
+                    pending_checkpoint[card_id] = (
+                        int(event["escalation_epoch"]), len(attempts), attempt_id,
+                    )
+        elif event_type == "preflight-failed":
+            _require_fields(event, {"preflight_passed", "failure_reasons"})
+            if event["preflight_passed"] is not False or not isinstance(
+                event["failure_reasons"], list
+            ) or not event["failure_reasons"]:
+                raise ValueError(
+                    f"{event['event_id']} preflight-failed 必須帶 false 與非空 failure_reasons"
+                )
+        elif event_type == "review-invalid":
+            _require_fields(event, {"preflight_passed", "invalid_reasons"})
+            if not isinstance(event["invalid_reasons"], list) or not event["invalid_reasons"]:
+                raise ValueError(f"{event['event_id']} review-invalid 必須帶非空 invalid_reasons")
+        elif event_type == "escalation-checkpoint":
+            _require_fields(event, {
+                "escalation_epoch", "trigger_attempt_id", "unique_attempt_count",
+                "checkpoint_decision", "checkpoint_rationale",
+            })
+            if not isinstance(event["unique_attempt_count"], int) or event["unique_attempt_count"] < 3:
+                raise ValueError(f"{event['event_id']} escalation checkpoint 至少需三個 attempt")
+            if event["checkpoint_decision"] not in {
+                "continue", "replan", "change-executor", "escalate",
+            }:
+                raise ValueError(f"{event['event_id']} checkpoint_decision 不合法")
+            expected = pending_checkpoint.get(card_id)
+            if expected is None:
+                raise ValueError(f"{event['event_id']} 沒有待處理的第三次以後 attempt")
+            expected_epoch, expected_count, trigger_attempt = expected
+            if (
+                event["escalation_epoch"] != expected_epoch
+                or
+                event["unique_attempt_count"] != expected_count
+                or event["trigger_attempt_id"] != trigger_attempt
+            ):
+                raise ValueError(
+                    f"{event['event_id']} checkpoint 必須對應 {expected_count} 個唯一 attempt"
+                )
+            key = (card_id, expected_epoch)
+            repeated_root = any(
+                len(attempts) >= 3
+                for attempts in root_cause_attempts.get(key, {}).values()
+            )
+            must_escalate = repeated_root or unresolved_carry.get(key, False)
+            if must_escalate and event["checkpoint_decision"] != "escalate":
+                raise ValueError(
+                    f"{event['event_id']} 存在三次重複根因或未閉合 finding，"
+                    "checkpoint_decision 必須為 escalate"
+                )
+            del pending_checkpoint[card_id]
+    if pending_checkpoint:
+        cards = ", ".join(sorted(pending_checkpoint))
+        raise ValueError(f"第三次以後可計數 attempt 缺 escalation-checkpoint：{cards}")
 
 
 def _latest_events(events: Iterable[dict[str, object]]) -> list[dict[str, object]]:
+    events = list(events)
+    _validate_review_contract(events)
     by_card: dict[str, list[dict[str, object]]] = {}
     for event in events:
         missing = REQUIRED_FIELDS - event.keys()

--- a/scripts/workflow_ledger.py
+++ b/scripts/workflow_ledger.py
@@ -36,17 +36,20 @@ def _require_fields(event: dict[str, object], fields: set[str]) -> None:
         )
 
 
-def _counted_review(event: dict[str, object]) -> bool:
-    if event["review_result"] != "REQUEST_CHANGES":
-        return False
-    return any(
+def _is_counted_finding(finding: dict[str, object]) -> bool:
+    return (
         finding["accepted"] is True
         and finding["status"] == "open"
         and finding["blocking"] is True
         and finding["finding_class"] in COUNTED_FINDING_CLASSES
         and finding["attribution"] == "executor"
-        for finding in event["findings"]
     )
+
+
+def _counted_review(event: dict[str, object]) -> bool:
+    if event["review_result"] != "REQUEST_CHANGES":
+        return False
+    return any(_is_counted_finding(finding) for finding in event["findings"])
 
 
 def _validate_finding(event_id: object, finding: object) -> dict[str, object]:
@@ -140,11 +143,17 @@ def _validate_review_contract(events: list[dict[str, object]]) -> None:
     enabled = False
     counted_attempts: dict[tuple[str, int], set[str]] = {}
     open_findings: dict[tuple[str, int], set[str]] = {}
-    root_cause_attempts: dict[tuple[str, int], dict[str, set[str]]] = {}
-    unresolved_carry: dict[tuple[str, int], bool] = {}
+    root_cause_findings: dict[
+        tuple[str, int], dict[str, set[tuple[str, str]]]
+    ] = {}
+    unresolved_carry: dict[tuple[str, int], set[str]] = {}
     pending_checkpoint: dict[str, tuple[int, int, str]] = {}
+    pending_finding_conflicts: dict[str, set[tuple[int, str, str]]] = {}
     current_epochs: dict[str, int] = {}
     known_attempts: dict[tuple[str, int], set[str]] = {}
+    count_eligible_attempts: dict[tuple[str, int], set[str]] = {}
+    counted_finding_ids: dict[tuple[str, int, str], set[str]] = {}
+    attempt_previous_open: dict[tuple[str, int, str], set[str]] = {}
     attempt_findings: dict[tuple[str, int, str], dict[str, dict[str, object]]] = {}
     for event in events:
         if event.get("contract_baseline") == REVIEW_CONTRACT:
@@ -162,6 +171,14 @@ def _validate_review_contract(events: list[dict[str, object]]) -> None:
             continue
         event_type = event.get("type")
         card_id = str(event["card_id"])
+        if (
+            pending_finding_conflicts.get(card_id)
+            and event_type != "review-correction"
+        ):
+            raise ValueError(
+                f"{event['event_id']} 前必須先以 review-correction 裁決 {card_id} "
+                "同一 attempt 的 finding 衝突"
+            )
         if card_id in pending_checkpoint and event_type != "escalation-checkpoint":
             raise ValueError(
                 f"{event['event_id']} 前必須先為 {card_id} 寫 escalation-checkpoint"
@@ -177,40 +194,44 @@ def _validate_review_contract(events: list[dict[str, object]]) -> None:
                 )
             key = (card_id, epoch)
             attempt_id = str(event["attempt_id"])
+            attempt_key = (card_id, epoch, attempt_id)
             known_attempts.setdefault(key, set()).add(attempt_id)
-            per_attempt = attempt_findings.setdefault((card_id, epoch, attempt_id), {})
+            if event["counts_toward_escalation"] is True:
+                count_eligible_attempts.setdefault(key, set()).add(attempt_id)
+            per_attempt = attempt_findings.setdefault(attempt_key, {})
+            conflicting_ids: set[str] = set()
             for finding in event["findings"]:
                 finding_id = str(finding["finding_id"])
                 previous = per_attempt.get(finding_id)
                 if previous is not None and _findings_conflict(previous, finding):
-                    raise ValueError(
-                        f"{event['event_id']} 同一 attempt 的 finding {finding_id} 衝突；"
-                        "必須追加 correction 事件裁決"
+                    pending_finding_conflicts.setdefault(card_id, set()).add(
+                        (epoch, attempt_id, finding_id)
                     )
+                    conflicting_ids.add(finding_id)
+                    continue
                 per_attempt.setdefault(finding_id, finding)
 
             attempts = counted_attempts.setdefault(key, set())
-            is_new_counted_attempt = (
-                event["counts_toward_escalation"] is True and attempt_id not in attempts
-            )
             previous_open = set(open_findings.setdefault(key, set()))
+            attempt_previous_open.setdefault(attempt_key, previous_open)
             for finding in event["findings"]:
+                finding_id = str(finding["finding_id"])
+                if finding_id in conflicting_ids:
+                    continue
                 _apply_finding_state(finding, open_findings[key])
-                if (
-                    event["counts_toward_escalation"] is True
-                    and finding["status"] == "open"
-                    and finding["accepted"] is True
-                    and finding["blocking"] is True
-                    and finding["finding_class"] in COUNTED_FINDING_CLASSES
-                    and finding["attribution"] == "executor"
-                ):
-                    roots = root_cause_attempts.setdefault(key, {})
-                    roots.setdefault(str(finding["root_cause_id"]), set()).add(attempt_id)
+                if event["counts_toward_escalation"] is True and _is_counted_finding(finding):
+                    counted_finding_ids.setdefault(attempt_key, set()).add(finding_id)
+                    roots = root_cause_findings.setdefault(key, {})
+                    roots.setdefault(str(finding["root_cause_id"]), set()).add(
+                        (attempt_id, finding_id)
+                    )
+            is_new_counted_attempt = (
+                bool(counted_finding_ids.get(attempt_key)) and attempt_id not in attempts
+            )
             if is_new_counted_attempt:
                 attempts.add(attempt_id)
-                unresolved_carry[key] = (
-                    unresolved_carry.get(key, False)
-                    or bool(previous_open & open_findings[key])
+                unresolved_carry.setdefault(key, set()).update(
+                    previous_open & open_findings[key]
                 )
                 if len(attempts) >= 3:
                     pending_checkpoint[card_id] = (
@@ -244,12 +265,13 @@ def _validate_review_contract(events: list[dict[str, object]]) -> None:
                 raise ValueError(f"{event['event_id']} correction escalation_epoch 不合法")
             key = (card_id, epoch)
             target_attempt = str(event["target_attempt_id"])
+            target_key = (card_id, epoch, target_attempt)
             updates = event["finding_updates"]
             if target_attempt not in known_attempts.get(key, set()):
                 raise ValueError(f"{event['event_id']} correction target_attempt_id 不存在")
             if not isinstance(updates, list) or not updates:
                 raise ValueError(f"{event['event_id']} finding_updates 必須為非空陣列")
-            target_findings = attempt_findings[(card_id, epoch, target_attempt)]
+            target_findings = attempt_findings[target_key]
             update_ids: set[str] = set()
             for finding in updates:
                 finding = _validate_finding(event["event_id"], finding)
@@ -261,8 +283,54 @@ def _validate_review_contract(events: list[dict[str, object]]) -> None:
                     raise ValueError(
                         f"{event['event_id']} correction finding_id 不存在：{finding_id}"
                     )
+                previous_finding = target_findings[finding_id]
                 target_findings[finding_id] = finding
                 _apply_finding_state(finding, open_findings.setdefault(key, set()))
+                pending_finding_conflicts.setdefault(card_id, set()).discard(
+                    (epoch, target_attempt, finding_id)
+                )
+                revokes_count = (
+                    finding["status"] == "withdrawn"
+                    or finding["accepted"] is False
+                    or (finding["status"] == "open" and not _is_counted_finding(finding))
+                )
+                root_changed = finding["root_cause_id"] != previous_finding["root_cause_id"]
+                if revokes_count or root_changed:
+                    for occurrences in root_cause_findings.get(key, {}).values():
+                        occurrences.difference_update({
+                            occurrence
+                            for occurrence in occurrences
+                            if occurrence[1] == finding_id
+                        })
+                if revokes_count:
+                    counted_finding_ids.setdefault(target_key, set()).discard(finding_id)
+                    unresolved_carry.setdefault(key, set()).discard(finding_id)
+                elif (
+                    target_attempt in count_eligible_attempts.get(key, set())
+                    and _is_counted_finding(finding)
+                ):
+                    counted_finding_ids.setdefault(target_key, set()).add(finding_id)
+                    roots = root_cause_findings.setdefault(key, {})
+                    roots.setdefault(str(finding["root_cause_id"]), set()).add(
+                        (target_attempt, finding_id)
+                    )
+            attempts = counted_attempts.setdefault(key, set())
+            was_counted = target_attempt in attempts
+            if counted_finding_ids.get(target_key):
+                attempts.add(target_attempt)
+                if not was_counted:
+                    unresolved_carry.setdefault(key, set()).update(
+                        attempt_previous_open.get(target_key, set())
+                        & open_findings.setdefault(key, set())
+                    )
+                    if len(attempts) >= 3:
+                        pending_checkpoint[card_id] = (
+                            epoch, len(attempts), target_attempt,
+                        )
+            else:
+                attempts.discard(target_attempt)
+            if not pending_finding_conflicts.get(card_id):
+                pending_finding_conflicts.pop(card_id, None)
         elif event_type == "preflight-failed":
             _require_fields(event, {"preflight_passed", "failure_reasons"})
             if event["preflight_passed"] is not False or not isinstance(
@@ -311,16 +379,19 @@ def _validate_review_contract(events: list[dict[str, object]]) -> None:
                 )
             key = (card_id, expected_epoch)
             repeated_root = any(
-                len(attempts) >= 3
-                for attempts in root_cause_attempts.get(key, {}).values()
+                len({attempt_id for attempt_id, _finding_id in occurrences}) >= 3
+                for occurrences in root_cause_findings.get(key, {}).values()
             )
-            must_escalate = repeated_root or unresolved_carry.get(key, False)
+            must_escalate = repeated_root or bool(unresolved_carry.get(key))
             if must_escalate and event["checkpoint_decision"] != "escalate":
                 raise ValueError(
                     f"{event['event_id']} 存在三次重複根因或未閉合 finding，"
                     "checkpoint_decision 必須為 escalate"
                 )
             del pending_checkpoint[card_id]
+    if pending_finding_conflicts:
+        cards = ", ".join(sorted(pending_finding_conflicts))
+        raise ValueError(f"同一 attempt 的 finding 衝突缺 review-correction：{cards}")
     if pending_checkpoint:
         cards = ", ".join(sorted(pending_checkpoint))
         raise ValueError(f"第三次以後可計數 attempt 缺 escalation-checkpoint：{cards}")

--- a/scripts/workflow_ledger.py
+++ b/scripts/workflow_ledger.py
@@ -121,15 +121,10 @@ def _apply_finding_state(
     finding: dict[str, object], current_open: set[str],
 ) -> None:
     finding_id = str(finding["finding_id"])
-    if finding["status"] in {"resolved", "withdrawn"}:
-        current_open.discard(finding_id)
-    elif (
-        finding["accepted"] is True
-        and finding["blocking"] is True
-        and finding["finding_class"] in COUNTED_FINDING_CLASSES
-        and finding["attribution"] == "executor"
-    ):
+    if _is_counted_finding(finding):
         current_open.add(finding_id)
+    else:
+        current_open.discard(finding_id)
 
 
 def _findings_conflict(
@@ -142,6 +137,7 @@ def _validate_review_contract(events: list[dict[str, object]]) -> None:
     """Baseline 前事件保持原貌；marker 之後 fail loud 驗證 WF-21 契約。"""
     enabled = False
     counted_attempts: dict[tuple[str, int], set[str]] = {}
+    counted_attempt_order: dict[tuple[str, int], list[str]] = {}
     open_findings: dict[tuple[str, int], set[str]] = {}
     root_cause_findings: dict[
         tuple[str, int], dict[str, set[tuple[str, str]]]
@@ -179,7 +175,15 @@ def _validate_review_contract(events: list[dict[str, object]]) -> None:
                 f"{event['event_id']} 前必須先以 review-correction 裁決 {card_id} "
                 "同一 attempt 的 finding 衝突"
             )
-        if card_id in pending_checkpoint and event_type != "escalation-checkpoint":
+        correction_can_resolve_conflict = (
+            event_type == "review-correction"
+            and bool(pending_finding_conflicts.get(card_id))
+        )
+        if (
+            card_id in pending_checkpoint
+            and event_type != "escalation-checkpoint"
+            and not correction_can_resolve_conflict
+        ):
             raise ValueError(
                 f"{event['event_id']} 前必須先為 {card_id} 寫 escalation-checkpoint"
             )
@@ -230,6 +234,7 @@ def _validate_review_contract(events: list[dict[str, object]]) -> None:
             )
             if is_new_counted_attempt:
                 attempts.add(attempt_id)
+                counted_attempt_order.setdefault(key, []).append(attempt_id)
                 unresolved_carry.setdefault(key, set()).update(
                     previous_open & open_findings[key]
                 )
@@ -295,13 +300,20 @@ def _validate_review_contract(events: list[dict[str, object]]) -> None:
                     or (finding["status"] == "open" and not _is_counted_finding(finding))
                 )
                 root_changed = finding["root_cause_id"] != previous_finding["root_cause_id"]
+                migrated_occurrences = {
+                    occurrence
+                    for occurrences in root_cause_findings.get(key, {}).values()
+                    for occurrence in occurrences
+                    if occurrence[1] == finding_id
+                }
                 if revokes_count or root_changed:
                     for occurrences in root_cause_findings.get(key, {}).values():
-                        occurrences.difference_update({
-                            occurrence
-                            for occurrence in occurrences
-                            if occurrence[1] == finding_id
-                        })
+                        occurrences.difference_update(migrated_occurrences)
+                if root_changed and not revokes_count:
+                    roots = root_cause_findings.setdefault(key, {})
+                    roots.setdefault(str(finding["root_cause_id"]), set()).update(
+                        migrated_occurrences
+                    )
                 if revokes_count:
                     counted_finding_ids.setdefault(target_key, set()).discard(finding_id)
                     unresolved_carry.setdefault(key, set()).discard(finding_id)
@@ -319,6 +331,8 @@ def _validate_review_contract(events: list[dict[str, object]]) -> None:
             if counted_finding_ids.get(target_key):
                 attempts.add(target_attempt)
                 if not was_counted:
+                    if target_attempt not in counted_attempt_order.setdefault(key, []):
+                        counted_attempt_order[key].append(target_attempt)
                     unresolved_carry.setdefault(key, set()).update(
                         attempt_previous_open.get(target_key, set())
                         & open_findings.setdefault(key, set())
@@ -329,6 +343,19 @@ def _validate_review_contract(events: list[dict[str, object]]) -> None:
                         )
             else:
                 attempts.discard(target_attempt)
+            pending = pending_checkpoint.get(card_id)
+            if pending is not None and pending[0] == epoch:
+                if len(attempts) < 3:
+                    del pending_checkpoint[card_id]
+                else:
+                    trigger = pending[2]
+                    if trigger not in attempts:
+                        trigger = next(
+                            attempt
+                            for attempt in reversed(counted_attempt_order.get(key, []))
+                            if attempt in attempts
+                        )
+                    pending_checkpoint[card_id] = (epoch, len(attempts), trigger)
             if not pending_finding_conflicts.get(card_id):
                 pending_finding_conflicts.pop(card_id, None)
         elif event_type == "preflight-failed":

--- a/tests/test_review_prompt.py
+++ b/tests/test_review_prompt.py
@@ -50,6 +50,37 @@ def test_card_sections_warns_when_no_review_heading(
     assert "警告：CARD-A 找不到可錨定的驗收章節" in capsys.readouterr().err
 
 
+def test_build_prompt_uses_wf21_review_outcomes(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _write_card(tmp_path, "驗收條件")
+    monkeypatch.setattr(review_prompt, "ROOT", tmp_path)
+    monkeypatch.setattr(review_prompt, "latest_handoff", lambda _card_id: ({
+        "tier": "T3",
+        "db_scope": "none",
+        "feature": "test",
+        "branch": "ai/test/CARD-A",
+        "source_sha": "a" * 40,
+        "evidence": "handoff",
+    }, []))
+    monkeypatch.setattr(
+        review_prompt, "independence", lambda *_args: ("new context", "detail")
+    )
+    monkeypatch.setattr(review_prompt, "review_worktree_block", lambda *_args: "worktree")
+    monkeypatch.setattr(review_prompt, "repro_commands", lambda _event: "pytest")
+    monkeypatch.setattr(review_prompt, "review_gates_block", lambda _events: "")
+    monkeypatch.setattr(review_prompt, "card_events", lambda _card_id: [])
+
+    prompt = review_prompt.build_prompt("CARD-A")
+
+    assert "PREFLIGHT_FAILED" in prompt
+    assert "BLOCKED" in prompt
+    assert "REVIEW_INVALID" in prompt
+    assert "APPROVE 或 REQUEST_CHANGES" in prompt
+    assert "APPROVE 或 REJECT" not in prompt
+    assert "finding_class" in prompt
+
+
 # --- spec 基線一致性（OPS-REVIEW-BASELINE1；canonical baseline-cascade §5） ---
 def _write_child(root: Path, initiative: str, baseline: str | None) -> None:
     path = root / "docs" / "tasks" / "CHILD-1.md"

--- a/tests/test_workflow_ledger.py
+++ b/tests/test_workflow_ledger.py
@@ -404,6 +404,113 @@ def test_review_contract_credits_resolution_from_correction_event() -> None:
     workflow_ledger.render_ledger([baseline, _review_event(), correction])
 
 
+def test_review_contract_allows_append_only_correction_after_same_attempt_conflict() -> None:
+    baseline = _contract_event("BASELINE-001", "contract-baseline", 1)
+    baseline["contract_baseline"] = workflow_ledger.REVIEW_CONTRACT
+    conflicting = _review_event(
+        state_version=3,
+        review_result="APPROVE",
+        findings=[_finding(status="resolved", disposition="reviewer says fixed")],
+        counts_toward_escalation=False,
+    )
+    conflicting["event_id"] = "REVIEW-003"
+    correction = _contract_event("CORRECTION-004", "review-correction", 4)
+    correction.update({
+        "escalation_epoch": 0,
+        "target_attempt_id": f"CARD-WF21-e0-{FULL_SHA}",
+        "finding_updates": [_finding(
+            status="withdrawn", accepted=False, blocking=False,
+            disposition="Coordinator adjudicated the conflict",
+        )],
+    })
+
+    workflow_ledger.render_ledger([
+        baseline, _review_event(), conflicting, correction,
+    ])
+
+
+def test_review_contract_withdrawn_correction_clears_prior_carry() -> None:
+    baseline = _contract_event("BASELINE-001", "contract-baseline", 1)
+    baseline["contract_baseline"] = workflow_ledger.REVIEW_CONTRACT
+    first = _review_event()
+    second_sha = "b" * 40
+    second = _review_event(
+        state_version=3,
+        source_sha=second_sha,
+        attempt_id=f"CARD-WF21-e0-{second_sha}",
+        findings=[
+            _finding(),
+            _finding(finding_id="F-002", root_cause_id="missing-boundary-check"),
+        ],
+    )
+    correction = _contract_event("CORRECTION-004", "review-correction", 4)
+    correction.update({
+        "escalation_epoch": 0,
+        "target_attempt_id": second["attempt_id"],
+        "finding_updates": [_finding(
+            status="withdrawn", accepted=False, blocking=False,
+            disposition="evidence disproved the accepted finding",
+        )],
+    })
+    third_sha = "c" * 40
+    third = _review_event(
+        state_version=5,
+        source_sha=third_sha,
+        attempt_id=f"CARD-WF21-e0-{third_sha}",
+        findings=[
+            _finding(
+                finding_id="F-002", root_cause_id="missing-boundary-check", status="resolved",
+                disposition="fixed",
+            ),
+            _finding(finding_id="F-003", root_cause_id="missing-boundary-check"),
+        ],
+    )
+    checkpoint = _contract_event("CHECKPOINT-006", "escalation-checkpoint", 6)
+    checkpoint.update({
+        "escalation_epoch": 0,
+        "trigger_attempt_id": third["attempt_id"],
+        "unique_attempt_count": 3,
+        "checkpoint_decision": "continue",
+        "checkpoint_rationale": "withdrawn finding no longer contributes carry or root history",
+    })
+
+    workflow_ledger.render_ledger([
+        baseline, first, second, correction, third, checkpoint,
+    ])
+
+
+def test_review_contract_withdrawn_correction_removes_attempt_from_count() -> None:
+    baseline = _contract_event("BASELINE-001", "contract-baseline", 1)
+    baseline["contract_baseline"] = workflow_ledger.REVIEW_CONTRACT
+    correction = _contract_event("CORRECTION-003", "review-correction", 3)
+    correction.update({
+        "escalation_epoch": 0,
+        "target_attempt_id": f"CARD-WF21-e0-{FULL_SHA}",
+        "finding_updates": [_finding(
+            status="withdrawn", accepted=False, blocking=False,
+            disposition="finding was not valid",
+        )],
+    })
+    reviews = []
+    for state_version, sha, finding_id in (
+        (4, "b" * 40, "F-002"),
+        (5, "c" * 40, "F-003"),
+    ):
+        reviews.append(_review_event(
+            state_version=state_version,
+            source_sha=sha,
+            attempt_id=f"CARD-WF21-e0-{sha}",
+            findings=[_finding(
+                finding_id=finding_id,
+                root_cause_id=f"root-{finding_id}",
+            )],
+        ))
+
+    workflow_ledger.render_ledger([
+        baseline, _review_event(), correction, *reviews,
+    ])
+
+
 def test_review_contract_rejects_conflicting_finding_in_same_attempt() -> None:
     baseline = _contract_event("BASELINE-001", "contract-baseline", 1)
     baseline["contract_baseline"] = workflow_ledger.REVIEW_CONTRACT

--- a/tests/test_workflow_ledger.py
+++ b/tests/test_workflow_ledger.py
@@ -511,6 +511,231 @@ def test_review_contract_withdrawn_correction_removes_attempt_from_count() -> No
     ])
 
 
+def _assert_open_correction_revocation_allows_continue(**finding_overrides: object) -> None:
+    baseline = _contract_event("BASELINE-001", "contract-baseline", 1)
+    baseline["contract_baseline"] = workflow_ledger.REVIEW_CONTRACT
+    correction = _contract_event("CORRECTION-003", "review-correction", 3)
+    correction.update({
+        "escalation_epoch": 0,
+        "target_attempt_id": f"CARD-WF21-e0-{FULL_SHA}",
+        "finding_updates": [_finding(
+            status="open", disposition="finding no longer counts", **finding_overrides,
+        )],
+    })
+    reviews = []
+    previous_id: str | None = None
+    for state_version, sha, finding_id in (
+        (4, "b" * 40, "F-002"),
+        (5, "c" * 40, "F-003"),
+        (6, "d" * 40, "F-004"),
+    ):
+        findings = []
+        if previous_id is not None:
+            findings.append(_finding(
+                finding_id=previous_id,
+                root_cause_id=f"root-{previous_id}",
+                status="resolved",
+                disposition="fixed",
+            ))
+        findings.append(_finding(
+            finding_id=finding_id,
+            root_cause_id=f"root-{finding_id}",
+        ))
+        reviews.append(_review_event(
+            state_version=state_version,
+            source_sha=sha,
+            attempt_id=f"CARD-WF21-e0-{sha}",
+            findings=findings,
+        ))
+        previous_id = finding_id
+    checkpoint = _contract_event("CHECKPOINT-007", "escalation-checkpoint", 7)
+    checkpoint.update({
+        "escalation_epoch": 0,
+        "trigger_attempt_id": reviews[-1]["attempt_id"],
+        "unique_attempt_count": 3,
+        "checkpoint_decision": "continue",
+        "checkpoint_rationale": "revoked open finding does not recreate carry",
+    })
+
+    workflow_ledger.render_ledger([
+        baseline, _review_event(), correction, *reviews, checkpoint,
+    ])
+
+
+def test_review_contract_accepted_false_open_correction_clears_open_state() -> None:
+    _assert_open_correction_revocation_allows_continue(accepted=False)
+
+
+def test_review_contract_nonblocking_open_correction_clears_open_state() -> None:
+    _assert_open_correction_revocation_allows_continue(blocking=False)
+
+
+def _conflict_checkpoint_events(*, withdraw_conflict: bool) -> list[dict]:
+    baseline = _contract_event("BASELINE-001", "contract-baseline", 1)
+    baseline["contract_baseline"] = workflow_ledger.REVIEW_CONTRACT
+    first = _review_event()
+    second_sha = "b" * 40
+    second = _review_event(
+        state_version=3,
+        source_sha=second_sha,
+        attempt_id=f"CARD-WF21-e0-{second_sha}",
+        findings=[_finding(finding_id="F-002", root_cause_id="root-2")],
+    )
+    withdraw_second = _contract_event("CORRECTION-004", "review-correction", 4)
+    withdraw_second.update({
+        "escalation_epoch": 0,
+        "target_attempt_id": second["attempt_id"],
+        "finding_updates": [_finding(
+            finding_id="F-002", root_cause_id="root-2", status="withdrawn",
+            accepted=False, blocking=False, disposition="temporarily withdrawn",
+        )],
+    })
+    third_sha = "c" * 40
+    third = _review_event(
+        state_version=5,
+        source_sha=third_sha,
+        attempt_id=f"CARD-WF21-e0-{third_sha}",
+        findings=[_finding(finding_id="F-003", root_cause_id="root-3")],
+    )
+    conflict = _review_event(
+        state_version=6,
+        source_sha=third_sha,
+        attempt_id=third["attempt_id"],
+        review_result="APPROVE",
+        findings=[_finding(
+            finding_id="F-003", root_cause_id="root-3", status="resolved",
+            disposition="conflicting reviewer result",
+        )],
+        counts_toward_escalation=False,
+    )
+    reinstate_second = _contract_event("CORRECTION-007", "review-correction", 7)
+    reinstate_second.update({
+        "escalation_epoch": 0,
+        "target_attempt_id": second["attempt_id"],
+        "finding_updates": [_finding(
+            finding_id="F-002", root_cause_id="root-2",
+            disposition="reinstated after evidence",
+        )],
+    })
+    resolve_conflict = _contract_event("CORRECTION-008", "review-correction", 8)
+    conflict_resolution = (
+        _finding(
+            finding_id="F-003", root_cause_id="root-3", status="withdrawn",
+            accepted=False, blocking=False,
+            disposition="Coordinator withdrew the conflicted finding",
+        )
+        if withdraw_conflict
+        else _finding(
+            finding_id="F-003", root_cause_id="root-3",
+            disposition="Coordinator adjudicated open",
+        )
+    )
+    resolve_conflict.update({
+        "escalation_epoch": 0,
+        "target_attempt_id": third["attempt_id"],
+        "finding_updates": [conflict_resolution],
+    })
+    checkpoint = _contract_event("CHECKPOINT-009", "escalation-checkpoint", 9)
+    checkpoint.update({
+        "escalation_epoch": 0,
+        "trigger_attempt_id": second["attempt_id"],
+        "unique_attempt_count": 3,
+        "checkpoint_decision": "escalate",
+        "checkpoint_rationale": "conflict resolved before mandatory checkpoint",
+    })
+
+    events = [
+        baseline, first, second, withdraw_second, third, conflict,
+        reinstate_second, resolve_conflict,
+    ]
+    if not withdraw_conflict:
+        events.append(checkpoint)
+    return events
+
+
+def test_review_contract_allows_conflict_correction_before_pending_checkpoint() -> None:
+    workflow_ledger.render_ledger(_conflict_checkpoint_events(withdraw_conflict=False))
+
+
+def test_review_contract_withdrawn_conflict_clears_pending_checkpoint() -> None:
+    workflow_ledger.render_ledger(_conflict_checkpoint_events(withdraw_conflict=True))
+
+
+def test_review_contract_root_change_migrates_all_finding_occurrences() -> None:
+    baseline = _contract_event("BASELINE-001", "contract-baseline", 1)
+    baseline["contract_baseline"] = workflow_ledger.REVIEW_CONTRACT
+    first = _review_event()
+    resolve_one_sha = "d" * 40
+    resolve_one = _review_event(
+        state_version=3,
+        source_sha=resolve_one_sha,
+        attempt_id=f"CARD-WF21-e0-{resolve_one_sha}",
+        review_result="APPROVE",
+        findings=[_finding(status="resolved", disposition="closed before next attempt")],
+        counts_toward_escalation=False,
+    )
+    second_sha = "b" * 40
+    second = _review_event(
+        state_version=4,
+        source_sha=second_sha,
+        attempt_id=f"CARD-WF21-e0-{second_sha}",
+    )
+    resolve_two_sha = "e" * 40
+    resolve_two = _review_event(
+        state_version=5,
+        source_sha=resolve_two_sha,
+        attempt_id=f"CARD-WF21-e0-{resolve_two_sha}",
+        review_result="APPROVE",
+        findings=[_finding(status="resolved", disposition="closed before correction")],
+        counts_toward_escalation=False,
+    )
+    root_change = _contract_event("CORRECTION-006", "review-correction", 6)
+    root_change.update({
+        "escalation_epoch": 0,
+        "target_attempt_id": second["attempt_id"],
+        "finding_updates": [_finding(
+            root_cause_id="rediagnosed-root", disposition="root cause re-diagnosed",
+        )],
+    })
+    resolve_correction_sha = "f" * 40
+    resolve_correction = _review_event(
+        state_version=7,
+        source_sha=resolve_correction_sha,
+        attempt_id=f"CARD-WF21-e0-{resolve_correction_sha}",
+        review_result="APPROVE",
+        findings=[_finding(
+            root_cause_id="rediagnosed-root", status="resolved",
+            disposition="closed after re-diagnosis",
+        )],
+        counts_toward_escalation=False,
+    )
+    third_sha = "c" * 40
+    third = _review_event(
+        state_version=8,
+        source_sha=third_sha,
+        attempt_id=f"CARD-WF21-e0-{third_sha}",
+        findings=[_finding(root_cause_id="rediagnosed-root")],
+    )
+    checkpoint = _contract_event("CHECKPOINT-009", "escalation-checkpoint", 9)
+    checkpoint.update({
+        "escalation_epoch": 0,
+        "trigger_attempt_id": third["attempt_id"],
+        "unique_attempt_count": 3,
+        "checkpoint_decision": "continue",
+        "checkpoint_rationale": "incorrectly ignores migrated repeated root",
+    })
+
+    try:
+        workflow_ledger.render_ledger([
+            baseline, first, resolve_one, second, resolve_two, root_change,
+            resolve_correction, third, checkpoint,
+        ])
+    except ValueError as error:
+        assert "checkpoint_decision 必須為 escalate" in str(error)
+    else:
+        raise AssertionError("root re-diagnosis 必須遷移該 finding 的所有 attempt occurrences")
+
+
 def test_review_contract_rejects_conflicting_finding_in_same_attempt() -> None:
     baseline = _contract_event("BASELINE-001", "contract-baseline", 1)
     baseline["contract_baseline"] = workflow_ledger.REVIEW_CONTRACT

--- a/tests/test_workflow_ledger.py
+++ b/tests/test_workflow_ledger.py
@@ -72,7 +72,7 @@ def test_review_contract_keeps_pre_baseline_history_unchanged() -> None:
 
 
 def test_review_contract_rejects_free_text_review_after_baseline() -> None:
-    baseline = _contract_event("BASELINE-001", "status", 1)
+    baseline = _contract_event("BASELINE-001", "contract-baseline", 1)
     baseline["contract_baseline"] = workflow_ledger.REVIEW_CONTRACT
     review = _review_event(review_result="REJECT")
 
@@ -84,8 +84,34 @@ def test_review_contract_rejects_free_text_review_after_baseline() -> None:
         raise AssertionError("WF-21 baseline 後不得接受自由文字 REJECT")
 
 
+def test_review_contract_rejects_duplicate_baseline_marker() -> None:
+    baseline = _contract_event("BASELINE-001", "contract-baseline", 1)
+    baseline["contract_baseline"] = workflow_ledger.REVIEW_CONTRACT
+    bypass = _review_event(review_result="REJECT")
+    bypass["contract_baseline"] = workflow_ledger.REVIEW_CONTRACT
+
+    try:
+        workflow_ledger.render_ledger([baseline, bypass])
+    except ValueError as error:
+        assert "contract_baseline" in str(error)
+    else:
+        raise AssertionError("baseline marker 只能出現一次，不得略過後續 review 驗證")
+
+
+def test_review_contract_rejects_baseline_marker_on_review_event() -> None:
+    bypass = _review_event(state_version=1, review_result="REJECT")
+    bypass["contract_baseline"] = workflow_ledger.REVIEW_CONTRACT
+
+    try:
+        workflow_ledger.render_ledger([bypass])
+    except ValueError as error:
+        assert "contract-baseline 事件" in str(error)
+    else:
+        raise AssertionError("baseline marker 不得附在 review 事件上略過驗證")
+
+
 def test_review_contract_derives_count_from_executor_finding() -> None:
-    baseline = _contract_event("BASELINE-001", "status", 1)
+    baseline = _contract_event("BASELINE-001", "contract-baseline", 1)
     baseline["contract_baseline"] = workflow_ledger.REVIEW_CONTRACT
 
     rendered = workflow_ledger.render_ledger([baseline, _review_event()])
@@ -94,7 +120,7 @@ def test_review_contract_derives_count_from_executor_finding() -> None:
 
 
 def test_review_contract_does_not_count_governance_finding() -> None:
-    baseline = _contract_event("BASELINE-001", "status", 1)
+    baseline = _contract_event("BASELINE-001", "contract-baseline", 1)
     baseline["contract_baseline"] = workflow_ledger.REVIEW_CONTRACT
     review = _review_event(
         findings=[_finding(finding_class="governance", attribution="coordinator")],
@@ -105,7 +131,7 @@ def test_review_contract_does_not_count_governance_finding() -> None:
 
 
 def test_review_contract_rejects_manually_declared_count() -> None:
-    baseline = _contract_event("BASELINE-001", "status", 1)
+    baseline = _contract_event("BASELINE-001", "contract-baseline", 1)
     baseline["contract_baseline"] = workflow_ledger.REVIEW_CONTRACT
     review = _review_event(counts_toward_escalation=False)
 
@@ -118,7 +144,7 @@ def test_review_contract_rejects_manually_declared_count() -> None:
 
 
 def test_review_contract_deduplicates_same_attempt_before_checkpoint() -> None:
-    baseline = _contract_event("BASELINE-001", "status", 1)
+    baseline = _contract_event("BASELINE-001", "contract-baseline", 1)
     baseline["contract_baseline"] = workflow_ledger.REVIEW_CONTRACT
     same_attempt = _review_event(state_version=3)
     same_attempt["event_id"] = "REVIEW-003"
@@ -166,7 +192,7 @@ def test_review_contract_deduplicates_same_attempt_before_checkpoint() -> None:
 
 
 def test_review_contract_requires_checkpoint_after_third_unique_attempt() -> None:
-    baseline = _contract_event("BASELINE-001", "status", 1)
+    baseline = _contract_event("BASELINE-001", "contract-baseline", 1)
     baseline["contract_baseline"] = workflow_ledger.REVIEW_CONTRACT
     reviews = [_review_event()]
     for state_version, sha in ((3, "b" * 40), (4, "c" * 40)):
@@ -185,7 +211,7 @@ def test_review_contract_requires_checkpoint_after_third_unique_attempt() -> Non
 
 
 def test_review_contract_forces_escalation_for_repeated_root_cause() -> None:
-    baseline = _contract_event("BASELINE-001", "status", 1)
+    baseline = _contract_event("BASELINE-001", "contract-baseline", 1)
     baseline["contract_baseline"] = workflow_ledger.REVIEW_CONTRACT
     reviews = [_review_event()]
     for state_version, sha in ((3, "b" * 40), (4, "c" * 40)):
@@ -209,6 +235,233 @@ def test_review_contract_forces_escalation_for_repeated_root_cause() -> None:
         assert "checkpoint_decision 必須為 escalate" in str(error)
     else:
         raise AssertionError("三次重複根因必須 fail loud 升級")
+
+
+def test_review_contract_forces_escalation_for_unresolved_carry() -> None:
+    baseline = _contract_event("BASELINE-001", "contract-baseline", 1)
+    baseline["contract_baseline"] = workflow_ledger.REVIEW_CONTRACT
+    first = _review_event()
+    second_sha = "b" * 40
+    second = _review_event(
+        state_version=3,
+        source_sha=second_sha,
+        attempt_id=f"CARD-WF21-e0-{second_sha}",
+        findings=[
+            _finding(),
+            _finding(finding_id="F-002", root_cause_id="root-2"),
+        ],
+    )
+    third_sha = "c" * 40
+    third = _review_event(
+        state_version=4,
+        source_sha=third_sha,
+        attempt_id=f"CARD-WF21-e0-{third_sha}",
+        findings=[
+            _finding(status="resolved", disposition="fixed late"),
+            _finding(finding_id="F-002", root_cause_id="root-2", status="resolved"),
+            _finding(finding_id="F-003", root_cause_id="root-3"),
+        ],
+    )
+    checkpoint = _contract_event("CHECKPOINT-005", "escalation-checkpoint", 5)
+    checkpoint.update({
+        "escalation_epoch": 0,
+        "trigger_attempt_id": third["attempt_id"],
+        "unique_attempt_count": 3,
+        "checkpoint_decision": "continue",
+        "checkpoint_rationale": "incorrectly ignores carry from first to second attempt",
+    })
+
+    try:
+        workflow_ledger.render_ledger([baseline, first, second, third, checkpoint])
+    except ValueError as error:
+        assert "checkpoint_decision 必須為 escalate" in str(error)
+    else:
+        raise AssertionError("前輪 finding 延續到下一 attempt 必須 fail loud 升級")
+
+
+def test_review_contract_rejects_unauthorized_epoch_jump() -> None:
+    baseline = _contract_event("BASELINE-001", "contract-baseline", 1)
+    baseline["contract_baseline"] = workflow_ledger.REVIEW_CONTRACT
+    second_sha = "b" * 40
+    second = _review_event(
+        state_version=3,
+        source_sha=second_sha,
+        attempt_id=f"CARD-WF21-e0-{second_sha}",
+        findings=[_finding(finding_id="F-002", root_cause_id="root-2")],
+    )
+    third_sha = "c" * 40
+    jumped = _review_event(
+        state_version=4,
+        source_sha=third_sha,
+        escalation_epoch=1,
+        attempt_id=f"CARD-WF21-e1-{third_sha}",
+        findings=[_finding(finding_id="F-003", root_cause_id="root-3")],
+    )
+
+    try:
+        workflow_ledger.render_ledger([baseline, _review_event(), second, jumped])
+    except ValueError as error:
+        assert "escalation_epoch" in str(error)
+    else:
+        raise AssertionError("未經需求方授權不得切換 escalation epoch")
+
+
+def test_review_contract_rejects_boolean_epoch() -> None:
+    baseline = _contract_event("BASELINE-001", "contract-baseline", 1)
+    baseline["contract_baseline"] = workflow_ledger.REVIEW_CONTRACT
+    review = _review_event(
+        escalation_epoch=False,
+        attempt_id=f"CARD-WF21-eFalse-{FULL_SHA}",
+    )
+
+    try:
+        workflow_ledger.render_ledger([baseline, review])
+    except ValueError as error:
+        assert "非負整數" in str(error)
+    else:
+        raise AssertionError("Python bool 不得冒充 escalation epoch 整數")
+
+
+def test_review_contract_accepts_requester_authorized_next_epoch() -> None:
+    baseline = _contract_event("BASELINE-001", "contract-baseline", 1)
+    baseline["contract_baseline"] = workflow_ledger.REVIEW_CONTRACT
+    epoch_change = _contract_event("EPOCH-002", "escalation-epoch-change", 2)
+    epoch_change.update({
+        "from_escalation_epoch": 0,
+        "to_escalation_epoch": 1,
+        "epoch_change_reason": "replan",
+        "requester_approved": True,
+    })
+    source_sha = "b" * 40
+    review = _review_event(
+        state_version=3,
+        source_sha=source_sha,
+        escalation_epoch=1,
+        attempt_id=f"CARD-WF21-e1-{source_sha}",
+    )
+
+    workflow_ledger.render_ledger([baseline, epoch_change, review])
+
+
+def test_review_contract_credits_resolution_in_non_counted_review() -> None:
+    baseline = _contract_event("BASELINE-001", "contract-baseline", 1)
+    baseline["contract_baseline"] = workflow_ledger.REVIEW_CONTRACT
+    first = _review_event()
+    second_sha = "b" * 40
+    second = _review_event(
+        state_version=3,
+        source_sha=second_sha,
+        attempt_id=f"CARD-WF21-e0-{second_sha}",
+        findings=[
+            _finding(status="resolved", disposition="fixed"),
+            _finding(finding_id="F-002", root_cause_id="root-2"),
+        ],
+    )
+    resolution_sha = "d" * 40
+    resolution = _review_event(
+        state_version=4,
+        source_sha=resolution_sha,
+        attempt_id=f"CARD-WF21-e0-{resolution_sha}",
+        review_result="APPROVE",
+        findings=[_finding(
+            finding_id="F-002", root_cause_id="root-2", status="resolved",
+            disposition="verified fixed",
+        )],
+        counts_toward_escalation=False,
+        delivery_status="🔍待查核",
+    )
+    third_sha = "c" * 40
+    third = _review_event(
+        state_version=5,
+        source_sha=third_sha,
+        attempt_id=f"CARD-WF21-e0-{third_sha}",
+        findings=[_finding(finding_id="F-003", root_cause_id="root-3")],
+    )
+    checkpoint = _contract_event("CHECKPOINT-006", "escalation-checkpoint", 6)
+    checkpoint.update({
+        "escalation_epoch": 0,
+        "trigger_attempt_id": third["attempt_id"],
+        "unique_attempt_count": 3,
+        "checkpoint_decision": "continue",
+        "checkpoint_rationale": "all earlier findings are closed and roots converge",
+    })
+
+    workflow_ledger.render_ledger([
+        baseline, first, second, resolution, third, checkpoint,
+    ])
+
+
+def test_review_contract_credits_resolution_from_correction_event() -> None:
+    baseline = _contract_event("BASELINE-001", "contract-baseline", 1)
+    baseline["contract_baseline"] = workflow_ledger.REVIEW_CONTRACT
+    correction = _contract_event("CORRECTION-003", "review-correction", 3)
+    correction.update({
+        "escalation_epoch": 0,
+        "target_attempt_id": f"CARD-WF21-e0-{FULL_SHA}",
+        "finding_updates": [_finding(status="resolved", disposition="withdrawn after evidence")],
+    })
+
+    workflow_ledger.render_ledger([baseline, _review_event(), correction])
+
+
+def test_review_contract_rejects_conflicting_finding_in_same_attempt() -> None:
+    baseline = _contract_event("BASELINE-001", "contract-baseline", 1)
+    baseline["contract_baseline"] = workflow_ledger.REVIEW_CONTRACT
+    conflicting = _review_event(
+        state_version=3,
+        review_result="APPROVE",
+        findings=[_finding(status="resolved", disposition="another reviewer says fixed")],
+        counts_toward_escalation=False,
+    )
+    conflicting["event_id"] = "REVIEW-003"
+
+    try:
+        workflow_ledger.render_ledger([baseline, _review_event(), conflicting])
+    except ValueError as error:
+        assert "finding" in str(error) and "衝突" in str(error)
+    else:
+        raise AssertionError("同一 attempt 的 finding 衝突必須 fail loud")
+
+
+def test_review_invalid_requires_boolean_preflight_status() -> None:
+    baseline = _contract_event("BASELINE-001", "contract-baseline", 1)
+    baseline["contract_baseline"] = workflow_ledger.REVIEW_CONTRACT
+    invalid = _contract_event("INVALID-002", "review-invalid", 2)
+    invalid.update({"preflight_passed": "false", "invalid_reasons": ["wrong family"]})
+
+    try:
+        workflow_ledger.render_ledger([baseline, invalid])
+    except ValueError as error:
+        assert "preflight_passed" in str(error)
+    else:
+        raise AssertionError("review-invalid.preflight_passed 必須是布林值")
+
+
+def test_preflight_failed_requires_false_and_nonempty_reasons() -> None:
+    baseline = _contract_event("BASELINE-001", "contract-baseline", 1)
+    baseline["contract_baseline"] = workflow_ledger.REVIEW_CONTRACT
+    invalid = _contract_event("PREFLIGHT-002", "preflight-failed", 2)
+    invalid.update({"preflight_passed": True, "failure_reasons": []})
+
+    try:
+        workflow_ledger.render_ledger([baseline, invalid])
+    except ValueError as error:
+        assert "preflight-failed" in str(error)
+    else:
+        raise AssertionError("preflight-failed schema 不合法時必須拒絕")
+
+
+def test_approve_rejects_open_accepted_blocking_finding() -> None:
+    baseline = _contract_event("BASELINE-001", "contract-baseline", 1)
+    baseline["contract_baseline"] = workflow_ledger.REVIEW_CONTRACT
+    invalid = _review_event(review_result="APPROVE", counts_toward_escalation=False)
+
+    try:
+        workflow_ledger.render_ledger([baseline, invalid])
+    except ValueError as error:
+        assert "APPROVE" in str(error) and "blocking finding" in str(error)
+    else:
+        raise AssertionError("APPROVE 不得保留 accepted blocking finding")
 
 
 def test_render_ledger_uses_latest_event_for_each_card() -> None:

--- a/tests/test_workflow_ledger.py
+++ b/tests/test_workflow_ledger.py
@@ -8,6 +8,209 @@ workflow_ledger = importlib.util.module_from_spec(SPEC)
 SPEC.loader.exec_module(workflow_ledger)
 
 
+FULL_SHA = "a" * 40
+
+
+def _contract_event(event_id: str, event_type: str, state_version: int) -> dict:
+    return {
+        "event_id": event_id,
+        "card_id": "CARD-WF21",
+        "type": event_type,
+        "actor": "ruan6047",
+        "occurred_at": f"2026-07-30T12:00:0{state_version}+08:00",
+        "state_version": state_version,
+        "iteration": 0,
+        "source_sha": FULL_SHA,
+        "evidence": "test",
+        "initiative": "—",
+        "tier": "T4",
+        "feature": "WF-21 contract test",
+        "owner": "reviewer",
+        "branch_worktree": "ai/test/CARD-WF21 @ wt",
+        "delivery_status": "🔍待查核",
+        "deployment_status": "—不適用",
+    }
+
+
+def _finding(**overrides: object) -> dict:
+    finding = {
+        "finding_id": "F-001",
+        "severity": "major",
+        "blocking": True,
+        "accepted": True,
+        "status": "open",
+        "finding_class": "implementation",
+        "attribution": "executor",
+        "root_cause_id": "missing-boundary-check",
+        "evidence": "reproduced",
+        "disposition": "fix the boundary",
+    }
+    finding.update(overrides)
+    return finding
+
+
+def _review_event(state_version: int = 2, **overrides: object) -> dict:
+    event = _contract_event("REVIEW-002", "review", state_version)
+    event.update({
+        "attempt_id": f"CARD-WF21-e0-{FULL_SHA}",
+        "escalation_epoch": 0,
+        "preflight_passed": True,
+        "review_result": "REQUEST_CHANGES",
+        "findings": [_finding()],
+        "counts_toward_escalation": True,
+        "delivery_status": "↩退回",
+    })
+    event.update(overrides)
+    return event
+
+
+def test_review_contract_keeps_pre_baseline_history_unchanged() -> None:
+    legacy = _contract_event("LEGACY-REVIEW-001", "review", 1)
+    legacy["review_result"] = "REJECT（free text legacy）"
+
+    workflow_ledger.render_ledger([legacy])
+
+
+def test_review_contract_rejects_free_text_review_after_baseline() -> None:
+    baseline = _contract_event("BASELINE-001", "status", 1)
+    baseline["contract_baseline"] = workflow_ledger.REVIEW_CONTRACT
+    review = _review_event(review_result="REJECT")
+
+    try:
+        workflow_ledger.render_ledger([baseline, review])
+    except ValueError as error:
+        assert "APPROVE 或 REQUEST_CHANGES" in str(error)
+    else:
+        raise AssertionError("WF-21 baseline 後不得接受自由文字 REJECT")
+
+
+def test_review_contract_derives_count_from_executor_finding() -> None:
+    baseline = _contract_event("BASELINE-001", "status", 1)
+    baseline["contract_baseline"] = workflow_ledger.REVIEW_CONTRACT
+
+    rendered = workflow_ledger.render_ledger([baseline, _review_event()])
+
+    assert "CARD-WF21" in rendered
+
+
+def test_review_contract_does_not_count_governance_finding() -> None:
+    baseline = _contract_event("BASELINE-001", "status", 1)
+    baseline["contract_baseline"] = workflow_ledger.REVIEW_CONTRACT
+    review = _review_event(
+        findings=[_finding(finding_class="governance", attribution="coordinator")],
+        counts_toward_escalation=False,
+    )
+
+    workflow_ledger.render_ledger([baseline, review])
+
+
+def test_review_contract_rejects_manually_declared_count() -> None:
+    baseline = _contract_event("BASELINE-001", "status", 1)
+    baseline["contract_baseline"] = workflow_ledger.REVIEW_CONTRACT
+    review = _review_event(counts_toward_escalation=False)
+
+    try:
+        workflow_ledger.render_ledger([baseline, review])
+    except ValueError as error:
+        assert "推導為 True" in str(error)
+    else:
+        raise AssertionError("counts_toward_escalation 必須由 finding 推導")
+
+
+def test_review_contract_deduplicates_same_attempt_before_checkpoint() -> None:
+    baseline = _contract_event("BASELINE-001", "status", 1)
+    baseline["contract_baseline"] = workflow_ledger.REVIEW_CONTRACT
+    same_attempt = _review_event(state_version=3)
+    same_attempt["event_id"] = "REVIEW-003"
+    second_sha = "b" * 40
+    second = _review_event(
+        state_version=4,
+        source_sha=second_sha,
+        attempt_id=f"CARD-WF21-e0-{second_sha}",
+        findings=[
+            _finding(status="resolved"),
+            _finding(
+                finding_id="F-002", root_cause_id="missing-schema-check",
+                disposition="fix schema check",
+            ),
+        ],
+    )
+    third_sha = "c" * 40
+    third = _review_event(
+        state_version=5,
+        source_sha=third_sha,
+        attempt_id=f"CARD-WF21-e0-{third_sha}",
+        findings=[
+            _finding(
+                finding_id="F-002", root_cause_id="missing-schema-check",
+                status="resolved", disposition="fixed",
+            ),
+            _finding(
+                finding_id="F-003", root_cause_id="missing-epoch-check",
+                disposition="fix epoch check",
+            ),
+        ],
+    )
+    checkpoint = _contract_event("CHECKPOINT-006", "escalation-checkpoint", 6)
+    checkpoint.update({
+        "escalation_epoch": 0,
+        "trigger_attempt_id": third["attempt_id"],
+        "unique_attempt_count": 3,
+        "checkpoint_decision": "continue",
+        "checkpoint_rationale": "three distinct and converging findings",
+    })
+
+    workflow_ledger.render_ledger([
+        baseline, _review_event(), same_attempt, second, third, checkpoint,
+    ])
+
+
+def test_review_contract_requires_checkpoint_after_third_unique_attempt() -> None:
+    baseline = _contract_event("BASELINE-001", "status", 1)
+    baseline["contract_baseline"] = workflow_ledger.REVIEW_CONTRACT
+    reviews = [_review_event()]
+    for state_version, sha in ((3, "b" * 40), (4, "c" * 40)):
+        reviews.append(_review_event(
+            state_version=state_version,
+            source_sha=sha,
+            attempt_id=f"CARD-WF21-e0-{sha}",
+        ))
+
+    try:
+        workflow_ledger.render_ledger([baseline, *reviews])
+    except ValueError as error:
+        assert "缺 escalation-checkpoint" in str(error)
+    else:
+        raise AssertionError("第三個可計數 attempt 必須先進 checkpoint")
+
+
+def test_review_contract_forces_escalation_for_repeated_root_cause() -> None:
+    baseline = _contract_event("BASELINE-001", "status", 1)
+    baseline["contract_baseline"] = workflow_ledger.REVIEW_CONTRACT
+    reviews = [_review_event()]
+    for state_version, sha in ((3, "b" * 40), (4, "c" * 40)):
+        reviews.append(_review_event(
+            state_version=state_version,
+            source_sha=sha,
+            attempt_id=f"CARD-WF21-e0-{sha}",
+        ))
+    checkpoint = _contract_event("CHECKPOINT-005", "escalation-checkpoint", 5)
+    checkpoint.update({
+        "escalation_epoch": 0,
+        "trigger_attempt_id": reviews[-1]["attempt_id"],
+        "unique_attempt_count": 3,
+        "checkpoint_decision": "continue",
+        "checkpoint_rationale": "incorrectly ignore repeated cause",
+    })
+
+    try:
+        workflow_ledger.render_ledger([baseline, *reviews, checkpoint])
+    except ValueError as error:
+        assert "checkpoint_decision 必須為 escalate" in str(error)
+    else:
+        raise AssertionError("三次重複根因必須 fail loud 升級")
+
+
 def test_render_ledger_uses_latest_event_for_each_card() -> None:
     events = [
         {


### PR DESCRIPTION
## Summary
- adopt ai-workflow WF-21 with structured attempts and derived escalation state
- remove accepted=false and downgraded open findings from effective open state
- preserve resolved-but-not-revoked carry history
- allow review-correction to clear pending conflicts before an already-created checkpoint
- clear or recompute pending checkpoint state when correction changes counted attempts
- migrate every occurrence of a stable finding when root cause is re-diagnosed

## Verification
- `uv run ruff check`
- `uv run pytest -q`: 944 passed, 3 skipped, 1 existing deprecation warning
- exact focused command: `uv run pytest -q tests/test_workflow_ledger.py tests/test_review_prompt.py` → 105 passed
- `uv run python scripts/workflow_ledger.py --check`
- `git diff --check`
- commit trailer guard passes post-commit

## Review status
Claude Fable 5 iteration 2 returned `REQUEST_CHANGES`, counted as epoch 0 attempt 2. R-10 through R-12 are addressed at `3e48ee62a34b37da9548d38ec8c3efadbe28cd56`; canonical dependency is `e29f0f469261ce77a945c622dc0f125abf5b8886`. Keep draft until iteration 3 cross-family review approves and ruan6047/ai-workflow#6 merges.
