### PR TITLE
fix(tests): skip scoreless-streak ER-zero test when DB unreachable

### DIFF
--- a/tests/test_scoreless_streak_api.py
+++ b/tests/test_scoreless_streak_api.py
@@ -56,7 +56,10 @@ def test_every_counted_appearance_is_officially_er_zero():
     """
     from cpbl.api.scoreless import compute_all, load_appearances
 
-    by_player, _ = load_appearances(["A", "E", "C"])
+    try:
+        by_player, _ = load_appearances(["A", "E", "C"])
+    except Exception as exc:  # noqa: BLE001 — 無 DB 時跳過（CI 無 Postgres）
+        pytest.skip(f"需本機 DB：{exc}")
     if not by_player:
         pytest.skip("無出賽資料")
     results = compute_all(by_player, ("A",))


### PR DESCRIPTION
## Summary
- `test_every_counted_appearance_is_officially_er_zero` 直接呼叫 `load_appearances()`，繞過同檔案其餘測試共用的 `_get()` skip-on-no-DB 防護，導致 CI（無 Postgres）連續三次跑出 `PoolTimeout` 未捕捉例外，讓 `api` job 長紅（見 [DEV-CI-SCORELESS-DB-SKIP1](https://github.com/ruan6047/cpbl-analytics/blob/main/docs/tasks/DEV-CI-SCORELESS-DB-SKIP1.md)）。
- 補上與 `_get()` 一致的 `try/except pytest.skip`，斷言邏輯完全不變。

## Test plan
- [x] `uv run ruff check` 全綠
- [x] `uv run pytest -q`（本機有 DB）：1021 passed / 4 skipped，無回歸
- [x] 本機模擬 CI 無 DB 情境（`DATABASE_URL` 指向無人監聽的埠）：7 個需 DB 測試皆 skip（含本測試）、3 個純函式測試仍 pass，`0 failed`（修正前為 `1 failed`）
- [ ] 本 PR 的 GitHub Actions `api`／`web` 皆 success（待此 PR 觸發後確認）

🤖 Generated with [Claude Code](https://claude.com/claude-code)