### PR TITLE
DEV-CI-PYTEST-SLOW1: probe DB reachability once to kill repeated 30s pool timeouts in CI pytest

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,55 @@
+"""tests/ 全域設施：DB 可用性一次性探測（DEV-CI-PYTEST-SLOW1）。
+
+背景（計時證據，模擬 CI 無 DB：DATABASE_URL 指向無人監聽的埠）：
+`uv run pytest -q --durations=50` 顯示 25 個測試／fixture 各花 ~30.00–30.09
+秒，佔 781s 總時間的絕大部分；其餘 1000+ 測試合計不到 30 秒。這不是連線本身
+慢——`psycopg.connect()` 對不可達位址近乎瞬間失敗（ECONNREFUSED）——而是
+`cpbl.db.pool()` 建立的全域 `ConnectionPool`，其 `.connection()` 借連線在
+真正借不到時會等到 pool 的 checkout timeout（`ConnectionPool` 預設
+`timeout=30.0` 秒）才拋 `PoolTimeout`。因為沒有共用探測，每個各自
+try/except 再 `pytest.skip()` 的測試檔（test_records_api.py、
+test_daily_summary.py、test_coaches_history.py、test_scoreless_streak_api.py…）
+都各自付一次 30 秒，不會因為背後是同一個全域單例池而變快——空池不會記得
+「已知連不上」，每次借連線都重新等滿 timeout。
+
+修法：整個 pytest session 只在最開始做一次探測——用一條「用完即丟」的原生
+連線（不經過 pool、bounded connect_timeout=2s）快速確認 DB 是否可達。
+- **DB 不可達**：把 `cpbl.db._pool` 直接換成一個「未開啟」的池
+  （`ConnectionPool(..., open=False)`）——與 `tests/test_api_contract.py`
+  既有 `broken_db` fixture 同一手法（見該檔內註解）：任何借連線立即拋
+  `PoolClosed`，不必再等 30 秒 checkout timeout。
+- **DB 可達**：完全不碰 `_pool`，讓它照舊由第一個真正使用它的測試惰性建立
+  （`cpbl.db.pool()` 原本的行為）——與現行行為零差異，「有 DB 時照跑」。
+
+各測試檔既有的 try/except pytest.skip 邏輯完全不變：收到的例外從
+`PoolTimeout` 換成 `PoolClosed`，且幾乎瞬間發生；skip 條件維持等價，
+只是不必再乾等。
+"""
+
+from __future__ import annotations
+
+import psycopg
+from psycopg_pool import ConnectionPool
+
+from cpbl import db
+from cpbl.config import settings
+
+# 探測逾時：遠低於 pool 預設 30 秒 checkout timeout，但足夠讓真實本機/CI DB
+# （loopback 或近端網路）在正常情況下回應，避免把偶發的短暫延遲誤判為無 DB。
+_PROBE_CONNECT_TIMEOUT_SECONDS = 2
+
+# 與 tests/test_api_contract.py 的 broken_db fixture 同一手法：未開啟的池
+# 借連線立即拋 PoolClosed，不會嘗試真的連線、不會等待。
+_UNREACHABLE_DSN = "postgresql://x:x@127.0.0.1:1/x"
+
+
+def pytest_sessionstart(session) -> None:  # noqa: ANN001 — pytest hook 簽名固定
+    """整個 session 只探測一次；DB 不可達就讓全域池「預先壞掉」以避免逐測試等待。"""
+    del session  # 不需要用到，hook 簽名要求收下這個參數
+    try:
+        with psycopg.connect(
+            settings.database_url, connect_timeout=_PROBE_CONNECT_TIMEOUT_SECONDS
+        ):
+            pass
+    except Exception:  # noqa: BLE001 — 探測階段任何失敗都視為「無 DB」，交由各測試既有 skip 邏輯處理
+        db._pool = ConnectionPool(_UNREACHABLE_DSN, open=False)


### PR DESCRIPTION
## 查核通過前請勿 merge

## 卡片
DEV-CI-PYTEST-SLOW1（Issue #84）— CI pytest 結構性慢（763s vs 本機 30s）調查與修復。

## 根因（計時證據）
模擬 CI 無 DB 情境（`DATABASE_URL` 指向無人監聽的埠）跑 `uv run pytest -q --durations=50`：
25 個測試／fixture 各花 ~30.00–30.09 秒，佔總時間 781.05s 的絕大部分。

不是連線本身慢（`psycopg.connect()` 對不可達位址近乎瞬間失敗，實測 0.003s），
而是 `cpbl.db.pool()` 建立的全域 `ConnectionPool`，其 `.connection()` 借連線在真正
借不到時會等到 pool 的 checkout timeout（預設 30.0 秒）才拋 `PoolTimeout`。因為沒有
共用探測，每個各自 try/except 再 `pytest.skip()` 的測試檔（`test_records_api.py`、
`test_daily_summary.py`、`test_coaches_history.py`、`test_scoreless_streak_api.py` 等）
都各自付一次 30 秒——不會因為背後是同一個全域單例池而變快。

## 修法
新增 `tests/conftest.py`（不動任何既有測試檔）：`pytest_sessionstart` 在 session 一開始
用一條「用完即丟」的原生連線（bounded `connect_timeout=2s`）探測一次。
- **DB 不可達**：把 `cpbl.db._pool` 換成一個「未開啟」的池（`ConnectionPool(..., open=False)`
  ——與 `tests/test_api_contract.py` 既有 `broken_db` fixture 同一手法），任何借連線立即拋
  `PoolClosed`，不必再等 30 秒。
- **DB 可達**：完全不碰 `_pool`，讓它照舊由第一個真正使用它的測試惰性建立，與現行行為
  零差異。

各測試檔既有的 try/except pytest.skip 邏輯完全不變，skip 語意維持等價，只是不必再乾等。

## 本機驗證

| 場景 | 修正前 | 修正後 |
|---|---|---|
| 模擬無 DB（`--durations=50`） | 781.05s（1 failed／1049 passed／29 skipped） | 12.19s（1 failed／1049 passed／29 skipped，最慢測試 0.47s） |
| 真實本機 DB | — | 13-14s（1074 passed／4 skipped：25 個原本逾時 skip 的測試現在連線成功並通過，29-25=4 對得上，確認 skip 條件等價未放寬） |

`uv run ruff check` 全綠。

## 已知、與本卡無關的既有失敗
兩個場景都各有 1 個既有失敗：`test_task_card_sections.py::test_active_cards_with_new_lifecycle_events_have_review_sections`。
原因是 `docs/control-plane/events.jsonl` 對 `DEV-CI-RED-OWNERSHIP1` 的最新狀態是「🛑已停止」
（非「🏁完成」)，但 `docs/tasks/DEV-CI-RED-OWNERSHIP1.md` 從未建立；已用 `git show origin/main:...`
確認 **origin/main tip 上同樣重現**，與 DB／本卡改動無關。已另開缺陷回報（分開處理），
不在本卡範圍（redline：不碰 `docs/control-plane/**`）。

## 驗收條件對照
- [x] 以逐測試計時證據定位慢源（`--durations=50`，見上）
- [x] 修法實測 CI Pytest step 時間顯著下降（本機模擬 781s → 12s；CI 真實對照見下方 checks）
- [x] 不放寬任何測試語意；skip 條件維持等價（DB 可達時 25 個測試從 skip 轉為 pass）

## Test plan
- [x] `uv run ruff check`
- [x] `uv run pytest -q`（本機有 DB，除上述既有無關失敗外全綠）
- [ ] 真實 CI run（api job）時間 vs 基線 763s —— 待 `gh pr checks --watch` 對照

🤖 Generated with [Claude Code](https://claude.com/claude-code)