### PR TITLE
fix(dev): DEV-STALE-GUARD-TESTS1 — recognize archived-card semantics in stale guard test

### DIFF
--- a/tests/test_task_card_sections.py
+++ b/tests/test_task_card_sections.py
@@ -21,6 +21,17 @@ def _events() -> list[dict[str, object]]:
 
 
 def test_active_cards_with_new_lifecycle_events_have_review_sections() -> None:
+    """流程守門生效後有 lifecycle event 的活卡，卡面須有可錨定的驗收章節。
+
+    2026-08-04 狀態面 cutover：`events.jsonl` 封存唯讀，`affected`／`active` 由
+    此刻起是固定集合，不會再有新卡加入。其中七張 🛑已停止 卡已依需求方裁決
+    `git mv` 進 `docs/archive/tasks/`（commit 9fbf406）——這不是資料流失，是
+    結案流程對帳過的搬遷，卡面內容仍在，只是換了目錄。本測試只稽核**仍在
+    `docs/tasks/` 的卡面**是否有驗收章節；已封存者略過，同下面兩支測試
+    （`test_statistical_t4_cards_have_a_redline_section`、
+    `test_initiative_children_baseline_matches_parent_version`）既有的
+    「已封存」跳過慣例，非新規則。
+    """
     events = _events()
     start = next(
         index for index, event in enumerate(events) if event["event_id"] == ENFORCEMENT_EVENT_ID
@@ -33,6 +44,9 @@ def test_active_cards_with_new_lifecycle_events_have_review_sections() -> None:
 
     missing = []
     for card_id in active:
+        path = ROOT / "docs" / "tasks" / f"{card_id}.md"
+        if not path.exists():
+            continue  # 已封存（archive 由結案流程對帳）
         if not review_prompt.card_sections(card_id, REVIEW_TOKENS):
             missing.append(card_id)
 


### PR DESCRIPTION
## Summary

closes #86

- `test_active_cards_with_new_lifecycle_events_have_review_sections`（`tests/test_task_card_sections.py`）仍假設每張有 lifecycle event 的活卡都有 `docs/tasks/<id>.md` 檔；cutover 後七張 🛑已停止 卡已依需求方裁決 `git mv` 進 `docs/archive/tasks/`（commit `9fbf406`），導致 `review_prompt.card_sections()` 對它們 `sys.exit`，origin/main 全庫 pytest 恆定 1 failed。
- 修法選 (a)：補上「已封存則略過」的跳過邏輯，鏡射同檔另兩支測試（`test_statistical_t4_cards_have_a_redline_section`、`test_initiative_children_baseline_matches_parent_version`）既有的慣例，而非整支退役——events.jsonl 凍結後仍有 13 張舊制活卡留在 `docs/tasks/`（如 `INGEST-PA-DAILY1`、`OPS-CODE-BRANCH-PROTECT1`），本測試對它們的「卡面須有可錨定驗收章節」稽核仍實質生效，守衛對象未消失。
- 範圍僅 `tests/test_task_card_sections.py`；未動 `docs/TASKS.md`、`docs/archive/**`、`docs/control-plane/**`，未搬任何卡檔。

## 本機全庫 pytest 前後對照

- **修法前**（origin/main `cb6a638`）：`1 failed, 1074 passed, 4 skipped`（唯一失敗：`test_active_cards_with_new_lifecycle_events_have_review_sections`，`SystemExit` 於 `DEV-CI-RED-OWNERSHIP1`）。
- **修法後**（本分支，同步 origin/main `ba06493` 後）：`1075 passed, 4 skipped`，零 failed。

## 順手盤點：其他仍讀 TASKS.md／docs/tasks 的守衛測試（列清單不修）

| 測試 | 讀取對象 | cutover 後語意是否仍成立 |
|---|---|---|
| `test_task_card_sections.py::test_statistical_t4_cards_have_a_redline_section` | 真實 `events.jsonl` + `docs/tasks/*.md` | ✅ 仍成立——已有 `if not path.exists(): continue` 略過封存卡，無需修改 |
| `test_task_card_sections.py::test_initiative_children_baseline_matches_parent_version` | 真實 `events.jsonl` + `docs/tasks/*.md`（子卡＋父卡） | ✅ 仍成立——子卡／父卡都已有略過封存的處理 |
| `test_task_card_sections.py::test_baseline_declaration_reads_the_declared_value_only` | 合成字串（無真實檔案） | ✅ 仍成立——不受 cutover 影響 |
| `test_review_prompt.py`（全部） | `docs/tasks/CARD-*.md` 等路徑 | ✅ 仍成立——全部經 `tmp_path` fixture 建構合成卡面，測的是 `review_prompt.py` 剖析邏輯本身，未讀真實 repo 檔案 |
| `test_workflow_ledger.py::test_real_event_log_passes_schema_and_replay_contract` | 真實 `docs/control-plane/events.jsonl`（經 `render_ledger` 全量 replay） | ⚠️ **語意已隨 cutover 淡出**：目的是擋「新 commit 加入 schema 不合法事件」，但 events.jsonl 已於 2026-08-04T23:47:31 封存唯讀、不再接受新事件，此測試防的錯已不可能再發生；因輸入凍結會恆綠，非本卡範圍不動 |
| `test_workflow_ledger.py::test_real_event_log_guard_actually_catches_malformed_events` | 真實 log 複本 + 手動注入的合成壞事件（負向測試） | 🟡 部分成立——驗證的是「驗證器邏輯仍抓得到壞資料」這個能力本身，與 events.jsonl 是否會有新資料無關，仍是有效的迴歸測試，但其防禦的觸發情境（新 commit 寫入壞事件）已不再發生 |
| `test_workflow_ledger.py` 其餘測試（`render_ledger`／`render_live` 系列） | 合成 fixture（`_contract_event`／`_review_event`／`_live_event`） | ✅ 仍成立——不讀真實 repo 檔案 |
| `test_scoreless_streak_no_logic_diff.py` | 僅 docstring 提及 `docs/tasks/ML-PITCHER-SCORELESS2.md` 做背景說明 | ✅ 不受影響——實際測試是 AST diff，與任務狀態面無關 |
| `test_state_plane_migrate.py` | 不讀 TASKS.md／docs/tasks | ✅ 不受影響 |

## Test plan

- [x] `uv run pytest -q` 全庫零 failed（本機已跑，見上）
- [x] `uv run ruff check tests/test_task_card_sections.py` 通過
- [ ] CI `api` job 全綠（等待 run URL）

**查核通過前請勿 merge。**

🤖 Generated with [Claude Code](https://claude.com/claude-code)