### PR TITLE
test: add pytest execution location header

### DIFF
--- a/docs/AI_RUNBOOK.md
+++ b/docs/AI_RUNBOOK.md
@@ -16,6 +16,13 @@
 
 ## 2. 環境與服務
 
+### pytest 證據位置
+
+每次 `pytest` 都會輸出 `pytest location` 三行：絕對 cwd、Git HEAD 短 SHA 與分支名。
+預設模式使用 pytest 標頭；`-q` 會隱藏 pytest 的標頭，故改由 terminal reporter 輸出相同內容。
+審閱測試證據時，以 cwd 與 SHA 判讀實際受測 worktree；**不可用收集數或 `.ai-workflow`
+submodule 狀態推斷測試位置**。非 Git 目錄時，HEAD 會顯示 `unavailable`，分支顯示 `detached`。
+
 | 場景 | DB | API | Web |
 |---|---|---|---|
 | **本機** | docker compose `db`（PG 17，**port 5433**） | `uvicorn cpbl.api.main:app --port 4001` | `web/` Next.js `:3000`（**兩個** env：`API_URL` 給 SSR、`NEXT_PUBLIC_API_URL` 給瀏覽器；預設皆 `:4001`） |

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -28,6 +28,9 @@ test_daily_summary.py、test_coaches_history.py、test_scoreless_streak_api.py�
 
 from __future__ import annotations
 
+import subprocess
+from pathlib import Path
+
 import psycopg
 from psycopg_pool import ConnectionPool
 
@@ -43,9 +46,36 @@ _PROBE_CONNECT_TIMEOUT_SECONDS = 2
 _UNREACHABLE_DSN = "postgresql://x:x@127.0.0.1:1/x"
 
 
+def _git_output(*args: str) -> str | None:
+    try:
+        return subprocess.run(
+            ["git", *args],
+            cwd=Path.cwd(),
+            capture_output=True,
+            check=True,
+            text=True,
+        ).stdout.strip() or None
+    except (OSError, subprocess.CalledProcessError):
+        return None
+
+
+def _location_header() -> list[str]:
+    head = _git_output("rev-parse", "--short", "HEAD") or "unavailable"
+    branch = _git_output("branch", "--show-current") or "detached"
+    return [
+        f"pytest location: cwd={Path.cwd()}",
+        f"pytest location: git_head={head}",
+        f"pytest location: git_branch={branch}",
+    ]
+
+
+def pytest_report_header(config) -> list[str]:  # noqa: ANN001 — pytest hook 簽名固定
+    del config
+    return _location_header()
+
+
 def pytest_sessionstart(session) -> None:  # noqa: ANN001 — pytest hook 簽名固定
     """整個 session 只探測一次；DB 不可達就讓全域池「預先壞掉」以避免逐測試等待。"""
-    del session  # 不需要用到，hook 簽名要求收下這個參數
     try:
         with psycopg.connect(
             settings.database_url, connect_timeout=_PROBE_CONNECT_TIMEOUT_SECONDS
@@ -53,3 +83,9 @@ def pytest_sessionstart(session) -> None:  # noqa: ANN001 — pytest hook 簽名
             pass
     except Exception:  # noqa: BLE001 — 探測階段任何失敗都視為「無 DB」，交由各測試既有 skip 邏輯處理
         db._pool = ConnectionPool(_UNREACHABLE_DSN, open=False)
+
+    if getattr(session.config.option, "quiet", 0):
+        reporter = session.config.pluginmanager.get_plugin("terminalreporter")
+        if reporter is not None:
+            for line in _location_header():
+                reporter.write_line(line)

--- a/tests/test_pytest_location_header.py
+++ b/tests/test_pytest_location_header.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+from contextlib import nullcontext
+from types import SimpleNamespace
+
+from tests import conftest
+
+
+def test_report_header_identifies_current_git_worktree(monkeypatch) -> None:
+    values = iter(("abc1234", "feature/example"))
+    monkeypatch.setattr(conftest, "_git_output", lambda *_: next(values))
+
+    assert conftest._location_header() == [
+        f"pytest location: cwd={conftest.Path.cwd()}",
+        "pytest location: git_head=abc1234",
+        "pytest location: git_branch=feature/example",
+    ]
+
+
+def test_report_header_marks_unavailable_git_metadata(monkeypatch) -> None:
+    monkeypatch.setattr(conftest, "_git_output", lambda *_: None)
+
+    assert conftest._location_header()[1:] == [
+        "pytest location: git_head=unavailable",
+        "pytest location: git_branch=detached",
+    ]
+
+
+def test_quiet_mode_writes_location_header(monkeypatch) -> None:
+    lines: list[str] = []
+    reporter = SimpleNamespace(write_line=lines.append)
+    session = SimpleNamespace(
+        config=SimpleNamespace(
+            option=SimpleNamespace(quiet=1),
+            pluginmanager=SimpleNamespace(get_plugin=lambda _: reporter),
+        )
+    )
+    monkeypatch.setattr(conftest.psycopg, "connect", lambda *_, **__: nullcontext())
+    monkeypatch.setattr(conftest, "_location_header", lambda: ["location"])
+
+    conftest.pytest_sessionstart(session)
+
+    assert lines == ["location"]


### PR DESCRIPTION
## 目的

讓 pytest 證據自帶 worktree、HEAD 與分支，避免查核者誤用其他 checkout 的測試結果。

## 變更

- 預設模式透過 pytest header 輸出位置資訊。
- `-q` 模式改由 terminal reporter 輸出同一資訊。
- 加入 Git 資訊不可取得時的降級測試，並在 Runbook 記錄判讀方式。

## 驗證

- `uv run ruff check`
- `uv run pytest`（1497 passed、10 skipped）

## 審核

T2：請由獨立查核者確認 cwd、SHA、branch 在預設與 `-q` 下皆可見。