### PR TITLE
docs: clarify G4 freeze resolution

### DIFF
--- a/docs/AI_WORKFLOW.md
+++ b/docs/AI_WORKFLOW.md
@@ -23,6 +23,6 @@
 8. **卡範圍與鏈式停損**：一根問題一張卡（卡內多個窄寫入授權）；每卡必填「服務的原始目標」，鏈深硬上限＝原始目標下 2 層，全域問題脫鏈獨立卡（canonical §2.11–2.12／§3.2–3.3）。
 9. **三級閘門**：Initiative／不可逆 T4 同步 grilling；T3 核心痛點三問批註放行；T2+ 前提逐條附實查證據（canonical §3.1）。
 10. **資源與 worktree**：派工前寫入集交集檢查（`file:`／`db:` 宣告；**merge 後 file 資源即釋放**、`📦已合併` 仍佔活卡）；worktree 註冊制＋doctor 對帳（canonical §4.4–4.5）。
-11. **派工包六條**：範圍外發現回報 PM 禁 spawn_task／不停等背景通知／禁 `gh pr update-branch`／詭異數據人工判讀＋新聞佐證四約束（僅定性、官方數值權威、URL＋日期、第三方泛化）／trailer 連續單一區塊／CLI 探索紅線（[`dispatch-package.md`](../.ai-workflow/templates/dispatch-package.md)）。**本專案當前仍有副作用的 CLI 入口：`cpbl-refresh-recent`（連 `--help` 都會觸發每日鏈；G4 凍結中，收窗後修）**。
+11. **派工包六條**：範圍外發現回報 PM 禁 spawn_task／不停等背景通知／禁 `gh pr update-branch`／詭異數據人工判讀＋新聞佐證四約束（僅定性、官方數值權威、URL＋日期、第三方泛化）／trailer 連續單一區塊／CLI 探索紅線（[`dispatch-package.md`](../.ai-workflow/templates/dispatch-package.md)）。**本專案當前仍有副作用的 CLI 入口：`cpbl-refresh-recent`（連 `--help` 都會觸發每日鏈）；此限制仍在，但 Gate 3 已於 2026-08-03 提前收窗並解除 G4 凍結，修正 `--help` 行為的前置條件已滿足**（[`INGEST-GAME-TM-REFACTOR1-G4.md`](tasks/INGEST-GAME-TM-REFACTOR1-G4.md) L21、L362）。
 
 決策（開卡／派工／merge／結案）＝需求方本人；機械寫入、派工包組裝與查核詞產製＝PM 祕書 session（canonical §1.1，Coordinator 職責由該 session 承擔）。同一卡的執行者不得兼任查核者：一般卡查核以新 context／session 為獨立即可，紅線卡須換模型家族或人工審核。

--- a/docs/tasks/DATA-TZ-BOUNDARY1.md
+++ b/docs/tasks/DATA-TZ-BOUNDARY1.md
@@ -16,7 +16,7 @@
 
 - [ ] 全庫 SQL 盤點 CURRENT_DATE/CURRENT_TIMESTAMP/now() 日期界線用點（artifact 由指令產生），逐點分類：語意敏感／無害／鏈端凍結
 - [ ] 語意敏感點改 (now() AT TIME ZONE 'Asia/Taipei')::date（沿 completion.py helper 模式）；C12 精確等值用點修復＋回歸
-- [ ] 鏈端（src/cpbl/ingest/）用點只記錄不改——G4 觀測凍結，併 REMEDY1 Phase 2 處理
+- [ ] 鏈端（`src/cpbl/ingest/`）用點：#113 已將 `run_refresh_recent.py` 的完成場判準改為共用 `completed_games_sql()`，故不再是「只記錄不改」；但該 helper 預設仍為 UTC，且 `cpbl_pitch_tracking.py` 仍有原始 `CURRENT_DATE` 用點。兩者的 Asia/Taipei 日界切換須以另行授權的鏈端實作卡處理；Gate 3 已於 2026-08-03 提前收窗並解除 G4 凍結，不能再以凍結作為延後理由（[`INGEST-GAME-TM-REFACTOR1-G4.md`](INGEST-GAME-TM-REFACTOR1-G4.md) L21、L362）。
 - [ ] 回歸：晨間窗口語意測試不依賴牆鐘（注入時間或斷言 SQL 形態＋DB 端雙時區日期差驗證）
 - [ ] uv run ruff check＋uv run pytest 全綠
 


### PR DESCRIPTION
## 變更

- 將 G4 觀測凍結已解除的事實同步至工作流程與 DATA-TZ-BOUNDARY1。
- 保留 `cpbl-refresh-recent --help` 仍有副作用的限制，明示修正前置已滿足。

## 驗證

- `uv run ruff check`
- 獨立查核：APPROVE（core_pain_resolved: yes；self_run: yes）

不執行任何 crawler CLI 或 DB 操作。