### PR TITLE
fix: retire stale G4 freeze rationale

### DIFF
--- a/docs/research/DATA-TZ-BOUNDARY1/inventory.json
+++ b/docs/research/DATA-TZ-BOUNDARY1/inventory.json
@@ -1,52 +1,49 @@
 {
-  "generated_at": "2026-08-05T14:26:31+08:00",
+  "generated_at": "2026-08-09T00:20:11+08:00",
   "db_timezone_note": "DB SHOW timezone = UTC；game_date 語意為台北日。",
   "direction_asymmetry": "AUDIT1 C12 把 range 一律視為無害，本卡實測補正：只有**上界**（<=）在 UTC 落後時是保守的；**下界**（>=）方向相反，會把昨天算進「今天起」。",
   "self_reference_note": "掃描器走 git ls-files，故本卡的掃描器與其測試入樹後必然掃到自己。這些命中歸入 tooling_self_reference 明確計列，**不計入** runtime 統計，使 artifact 在工具入樹前後都是同一個答案（R1 查核 TZBD1-R1-1）。",
-  "total_occurrences": 219,
-  "runtime_occurrences": 172,
+  "total_occurrences": 240,
+  "runtime_occurrences": 188,
   "self_reference_occurrences": 30,
   "self_reference_files": [
     "scripts/data_tz_boundary1.py",
     "tests/test_tz_boundary.py"
   ],
   "by_category": {
-    "timestamp_write": 101,
-    "upper_bound": 30,
+    "timestamp_write": 104,
+    "upper_bound": 32,
+    "already_taipei": 30,
     "tooling_self_reference": 30,
-    "already_taipei": 20,
-    "comment_or_string": 17,
+    "comment_or_string": 22,
     "meta_reference": 9,
-    "unclassified": 3,
+    "unclassified": 4,
     "lower_bound": 3,
     "exact_equality": 3,
-    "window_offset": 2,
-    "default_parameter": 1
+    "window_offset": 3
   },
   "by_zone": {
     "scripts": 64,
-    "migrations": 39,
-    "chain_frozen": 36,
+    "chain_deferred_pending_phase_b": 43,
+    "migrations": 41,
+    "tests": 32,
     "tooling_self_reference": 30,
-    "in_scope": 28,
-    "tests": 22
+    "in_scope": 30
   },
   "by_sensitivity": {
-    "無害": 110,
-    "無害-保守": 30,
+    "無害": 113,
+    "無害-保守": 32,
+    "已修正": 30,
     "無害-自指": 30,
-    "已修正": 20,
-    "說明文字": 17,
-    "敏感-中": 5,
-    "待人工判讀": 3,
-    "敏感-高": 3,
-    "敏感-低": 1
+    "說明文字": 22,
+    "敏感-中": 6,
+    "待人工判讀": 4,
+    "敏感-高": 3
   },
   "sensitive_total": 9,
-  "sensitive_in_scope": [
-    "src/cpbl/completion.py:54"
-  ],
-  "sensitive_chain_frozen_record_only": [
+  "sensitive_in_scope": [],
+  "sensitive_chain_deferred_pending_phase_b": [
+    "src/cpbl/ingest/cpbl_gamelog.py:347",
     "src/cpbl/ingest/cpbl_pitch_tracking.py:306",
     "src/cpbl/ingest/run_refresh_recent.py:140"
   ],
@@ -76,6 +73,15 @@
       "sensitivity": "待人工判讀",
       "rationale": "未落入既有規則，需人工看上下文",
       "code": "r\"CURRENT_DATE\\s*[<>]=?\", stripped):"
+    },
+    {
+      "file": "src/cpbl/completion.py",
+      "line": 59,
+      "zone": "in_scope",
+      "category": "unclassified",
+      "sensitivity": "待人工判讀",
+      "rationale": "未落入既有規則，需人工看上下文",
+      "code": "UTC_TODAY_SQL = \"CURRENT_DATE\""
     },
     {
       "file": "tests/test_completion.py",
@@ -438,6 +444,24 @@
       "sensitivity": "無害",
       "rationale": "純寫入時戳（trained_at/fetched_at/DEFAULT），不參與日期界線比較",
       "code": "created_at      timestamptz NOT NULL DEFAULT now(),"
+    },
+    {
+      "file": "migrations/071_box_pitching_revisions.sql",
+      "line": 30,
+      "zone": "migrations",
+      "category": "timestamp_write",
+      "sensitivity": "無害",
+      "rationale": "純寫入時戳（trained_at/fetched_at/DEFAULT），不參與日期界線比較",
+      "code": "fetched_at          timestamptz NOT NULL DEFAULT now(),"
+    },
+    {
+      "file": "migrations/071_box_pitching_revisions.sql",
+      "line": 31,
+      "zone": "migrations",
+      "category": "timestamp_write",
+      "sensitivity": "無害",
+      "rationale": "純寫入時戳（trained_at/fetched_at/DEFAULT），不參與日期界線比較",
+      "code": "last_seen_at        timestamptz NOT NULL DEFAULT now(),"
     },
     {
       "file": "scripts/audit_game_recap_data.py",
@@ -1178,6 +1202,15 @@
       "code": "\"generated_at\": datetime.now().isoformat(timespec=\"seconds\"),"
     },
     {
+      "file": "src/cpbl/api/routers/daily.py",
+      "line": 138,
+      "zone": "in_scope",
+      "category": "comment_or_string",
+      "sensitivity": "說明文字",
+      "rationale": "註解／docstring，非程式用點",
+      "code": "`TAIPEI_TODAY_SQL`」；此處是那條指示在 Python 側的對應物。"
+    },
+    {
       "file": "src/cpbl/api/routers/info.py",
       "line": 10,
       "zone": "in_scope",
@@ -1206,7 +1239,7 @@
     },
     {
       "file": "src/cpbl/api/routers/recap.py",
-      "line": 290,
+      "line": 292,
       "zone": "in_scope",
       "category": "upper_bound",
       "sensitivity": "無害-保守",
@@ -1287,7 +1320,16 @@
     },
     {
       "file": "src/cpbl/completion.py",
-      "line": 33,
+      "line": 24,
+      "zone": "in_scope",
+      "category": "comment_or_string",
+      "sensitivity": "說明文字",
+      "rationale": "註解／docstring，非程式用點",
+      "code": "目前**不同**——舊判準用 :data:`UTC_TODAY_SQL`、新判準用 :data:`TAIPEI_TODAY_SQL`。"
+    },
+    {
+      "file": "src/cpbl/completion.py",
+      "line": 52,
       "zone": "in_scope",
       "category": "comment_or_string",
       "sensitivity": "說明文字",
@@ -1296,7 +1338,7 @@
     },
     {
       "file": "src/cpbl/completion.py",
-      "line": 35,
+      "line": 54,
       "zone": "in_scope",
       "category": "already_taipei",
       "sensitivity": "已修正",
@@ -1305,16 +1347,16 @@
     },
     {
       "file": "src/cpbl/completion.py",
-      "line": 54,
+      "line": 59,
       "zone": "in_scope",
-      "category": "default_parameter",
-      "sensitivity": "敏感-低",
-      "rationale": "helper 預設參數；實際語意由呼叫端傳入值決定",
-      "code": "def completed_games_sql(as_of_sql: str = \"CURRENT_DATE\") -> str:"
+      "category": "unclassified",
+      "sensitivity": "待人工判讀",
+      "rationale": "未落入既有規則，需人工看上下文",
+      "code": "UTC_TODAY_SQL = \"CURRENT_DATE\""
     },
     {
       "file": "src/cpbl/completion.py",
-      "line": 57,
+      "line": 81,
       "zone": "in_scope",
       "category": "comment_or_string",
       "sensitivity": "說明文字",
@@ -1323,7 +1365,7 @@
     },
     {
       "file": "src/cpbl/completion.py",
-      "line": 61,
+      "line": 85,
       "zone": "in_scope",
       "category": "comment_or_string",
       "sensitivity": "說明文字",
@@ -1332,7 +1374,7 @@
     },
     {
       "file": "src/cpbl/completion.py",
-      "line": 86,
+      "line": 110,
       "zone": "in_scope",
       "category": "already_taipei",
       "sensitivity": "已修正",
@@ -1342,7 +1384,7 @@
     {
       "file": "src/cpbl/ingest/advanced_snapshot.py",
       "line": 117,
-      "zone": "chain_frozen",
+      "zone": "chain_deferred_pending_phase_b",
       "category": "timestamp_write",
       "sensitivity": "無害",
       "rationale": "純寫入時戳（trained_at/fetched_at/DEFAULT），不參與日期界線比較",
@@ -1351,7 +1393,7 @@
     {
       "file": "src/cpbl/ingest/advanced_snapshot.py",
       "line": 181,
-      "zone": "chain_frozen",
+      "zone": "chain_deferred_pending_phase_b",
       "category": "timestamp_write",
       "sensitivity": "無害",
       "rationale": "純寫入時戳（trained_at/fetched_at/DEFAULT），不參與日期界線比較",
@@ -1360,7 +1402,7 @@
     {
       "file": "src/cpbl/ingest/advanced_snapshot.py",
       "line": 195,
-      "zone": "chain_frozen",
+      "zone": "chain_deferred_pending_phase_b",
       "category": "timestamp_write",
       "sensitivity": "無害",
       "rationale": "純寫入時戳（trained_at/fetched_at/DEFAULT），不參與日期界線比較",
@@ -1369,16 +1411,34 @@
     {
       "file": "src/cpbl/ingest/advanced_snapshot.py",
       "line": 235,
-      "zone": "chain_frozen",
+      "zone": "chain_deferred_pending_phase_b",
       "category": "timestamp_write",
       "sensitivity": "無害",
       "rationale": "純寫入時戳（trained_at/fetched_at/DEFAULT），不參與日期界線比較",
       "code": "SET current_run_id=%s, promoted_at=now(),"
     },
     {
+      "file": "src/cpbl/ingest/box_revisions.py",
+      "line": 53,
+      "zone": "chain_deferred_pending_phase_b",
+      "category": "timestamp_write",
+      "sensitivity": "無害",
+      "rationale": "純寫入時戳（trained_at/fetched_at/DEFAULT），不參與日期界線比較",
+      "code": "SET last_seen_at = now(), seen_count = t.seen_count + 1"
+    },
+    {
+      "file": "src/cpbl/ingest/box_revisions.py",
+      "line": 182,
+      "zone": "chain_deferred_pending_phase_b",
+      "category": "comment_or_string",
+      "sensitivity": "說明文字",
+      "rationale": "註解／docstring，非程式用點",
+      "code": "# （`now()` 在台北 00:00–08:00 會落在前一個 UTC 曆日，與 completion.py 記載的"
+    },
+    {
       "file": "src/cpbl/ingest/cpbl_advanced.py",
       "line": 86,
-      "zone": "chain_frozen",
+      "zone": "chain_deferred_pending_phase_b",
       "category": "timestamp_write",
       "sensitivity": "無害",
       "rationale": "純寫入時戳（trained_at/fetched_at/DEFAULT），不參與日期界線比較",
@@ -1387,7 +1447,7 @@
     {
       "file": "src/cpbl/ingest/cpbl_advanced.py",
       "line": 258,
-      "zone": "chain_frozen",
+      "zone": "chain_deferred_pending_phase_b",
       "category": "timestamp_write",
       "sensitivity": "無害",
       "rationale": "純寫入時戳（trained_at/fetched_at/DEFAULT），不參與日期界線比較",
@@ -1396,7 +1456,7 @@
     {
       "file": "src/cpbl/ingest/cpbl_advanced.py",
       "line": 279,
-      "zone": "chain_frozen",
+      "zone": "chain_deferred_pending_phase_b",
       "category": "timestamp_write",
       "sensitivity": "無害",
       "rationale": "純寫入時戳（trained_at/fetched_at/DEFAULT），不參與日期界線比較",
@@ -1405,7 +1465,7 @@
     {
       "file": "src/cpbl/ingest/cpbl_coaches_history.py",
       "line": 686,
-      "zone": "chain_frozen",
+      "zone": "chain_deferred_pending_phase_b",
       "category": "timestamp_write",
       "sensitivity": "無害",
       "rationale": "純寫入時戳（trained_at/fetched_at/DEFAULT），不參與日期界線比較",
@@ -1414,16 +1474,61 @@
     {
       "file": "src/cpbl/ingest/cpbl_fighting.py",
       "line": 165,
-      "zone": "chain_frozen",
+      "zone": "chain_deferred_pending_phase_b",
       "category": "timestamp_write",
       "sensitivity": "無害",
       "rationale": "純寫入時戳（trained_at/fetched_at/DEFAULT），不參與日期界線比較",
       "code": ") + \", updated_at=now()\""
     },
     {
+      "file": "src/cpbl/ingest/cpbl_gamelog.py",
+      "line": 320,
+      "zone": "chain_deferred_pending_phase_b",
+      "category": "comment_or_string",
+      "sensitivity": "說明文字",
+      "rationale": "註解／docstring，非程式用點",
+      "code": "game_date <= CURRENT_DATE，避免保留賽掛未來日卻帶著中止時的比分被誤判成"
+    },
+    {
+      "file": "src/cpbl/ingest/cpbl_gamelog.py",
+      "line": 325,
+      "zone": "chain_deferred_pending_phase_b",
+      "category": "comment_or_string",
+      "sensitivity": "說明文字",
+      "rationale": "註解／docstring，非程式用點",
+      "code": "方向刻意用 UTC／`CURRENT_DATE`，不轉台北時區：與 `cpbl_pitch_tracking.py`"
+    },
+    {
+      "file": "src/cpbl/ingest/cpbl_gamelog.py",
+      "line": 331,
+      "zone": "chain_deferred_pending_phase_b",
+      "category": "upper_bound",
+      "sensitivity": "無害-保守",
+      "rationale": "UTC 落後只會晚 8 小時納入，永不誤納未來場",
+      "code": "\"AND home_score + away_score > 0 AND game_date <= CURRENT_DATE ORDER BY game_sno\","
+    },
+    {
+      "file": "src/cpbl/ingest/cpbl_gamelog.py",
+      "line": 346,
+      "zone": "chain_deferred_pending_phase_b",
+      "category": "upper_bound",
+      "sensitivity": "無害-保守",
+      "rationale": "UTC 落後只會晚 8 小時納入，永不誤納未來場",
+      "code": "\"AND home_score + away_score > 0 AND game_date <= CURRENT_DATE \""
+    },
+    {
+      "file": "src/cpbl/ingest/cpbl_gamelog.py",
+      "line": 347,
+      "zone": "chain_deferred_pending_phase_b",
+      "category": "window_offset",
+      "sensitivity": "敏感-中",
+      "rationale": "整個視窗連動位移一天",
+      "code": "\"AND game_date >= CURRENT_DATE - (%s * INTERVAL '1 day') \""
+    },
+    {
       "file": "src/cpbl/ingest/cpbl_home_runs.py",
       "line": 213,
-      "zone": "chain_frozen",
+      "zone": "chain_deferred_pending_phase_b",
       "category": "timestamp_write",
       "sensitivity": "無害",
       "rationale": "純寫入時戳（trained_at/fetched_at/DEFAULT），不參與日期界線比較",
@@ -1432,7 +1537,7 @@
     {
       "file": "src/cpbl/ingest/cpbl_live_game.py",
       "line": 54,
-      "zone": "chain_frozen",
+      "zone": "chain_deferred_pending_phase_b",
       "category": "timestamp_write",
       "sensitivity": "無害",
       "rationale": "純寫入時戳（trained_at/fetched_at/DEFAULT），不參與日期界線比較",
@@ -1441,7 +1546,7 @@
     {
       "file": "src/cpbl/ingest/cpbl_pitch_tracking.py",
       "line": 300,
-      "zone": "chain_frozen",
+      "zone": "chain_deferred_pending_phase_b",
       "category": "comment_or_string",
       "sensitivity": "說明文字",
       "rationale": "註解／docstring，非程式用點",
@@ -1450,7 +1555,7 @@
     {
       "file": "src/cpbl/ingest/cpbl_pitch_tracking.py",
       "line": 303,
-      "zone": "chain_frozen",
+      "zone": "chain_deferred_pending_phase_b",
       "category": "upper_bound",
       "sensitivity": "無害-保守",
       "rationale": "UTC 落後只會晚 8 小時納入，永不誤納未來場",
@@ -1459,7 +1564,7 @@
     {
       "file": "src/cpbl/ingest/cpbl_pitch_tracking.py",
       "line": 306,
-      "zone": "chain_frozen",
+      "zone": "chain_deferred_pending_phase_b",
       "category": "window_offset",
       "sensitivity": "敏感-中",
       "rationale": "整個視窗連動位移一天",
@@ -1468,7 +1573,7 @@
     {
       "file": "src/cpbl/ingest/cpbl_player_bio.py",
       "line": 95,
-      "zone": "chain_frozen",
+      "zone": "chain_deferred_pending_phase_b",
       "category": "timestamp_write",
       "sensitivity": "無害",
       "rationale": "純寫入時戳（trained_at/fetched_at/DEFAULT），不參與日期界線比較",
@@ -1477,7 +1582,7 @@
     {
       "file": "src/cpbl/ingest/cpbl_player_bio.py",
       "line": 98,
-      "zone": "chain_frozen",
+      "zone": "chain_deferred_pending_phase_b",
       "category": "timestamp_write",
       "sensitivity": "無害",
       "rationale": "純寫入時戳（trained_at/fetched_at/DEFAULT），不參與日期界線比較",
@@ -1486,7 +1591,7 @@
     {
       "file": "src/cpbl/ingest/cpbl_player_detail.py",
       "line": 180,
-      "zone": "chain_frozen",
+      "zone": "chain_deferred_pending_phase_b",
       "category": "timestamp_write",
       "sensitivity": "無害",
       "rationale": "純寫入時戳（trained_at/fetched_at/DEFAULT），不參與日期界線比較",
@@ -1495,7 +1600,7 @@
     {
       "file": "src/cpbl/ingest/cpbl_roster.py",
       "line": 70,
-      "zone": "chain_frozen",
+      "zone": "chain_deferred_pending_phase_b",
       "category": "timestamp_write",
       "sensitivity": "無害",
       "rationale": "純寫入時戳（trained_at/fetched_at/DEFAULT），不參與日期界線比較",
@@ -1504,7 +1609,7 @@
     {
       "file": "src/cpbl/ingest/cpbl_standings.py",
       "line": 89,
-      "zone": "chain_frozen",
+      "zone": "chain_deferred_pending_phase_b",
       "category": "timestamp_write",
       "sensitivity": "無害",
       "rationale": "純寫入時戳（trained_at/fetched_at/DEFAULT），不參與日期界線比較",
@@ -1513,7 +1618,7 @@
     {
       "file": "src/cpbl/ingest/cpbl_transactions.py",
       "line": 73,
-      "zone": "chain_frozen",
+      "zone": "chain_deferred_pending_phase_b",
       "category": "timestamp_write",
       "sensitivity": "無害",
       "rationale": "純寫入時戳（trained_at/fetched_at/DEFAULT），不參與日期界線比較",
@@ -1522,7 +1627,7 @@
     {
       "file": "src/cpbl/ingest/game_source_revisions.py",
       "line": 61,
-      "zone": "chain_frozen",
+      "zone": "chain_deferred_pending_phase_b",
       "category": "timestamp_write",
       "sensitivity": "無害",
       "rationale": "純寫入時戳（trained_at/fetched_at/DEFAULT），不參與日期界線比較",
@@ -1531,7 +1636,7 @@
     {
       "file": "src/cpbl/ingest/game_source_revisions.py",
       "line": 123,
-      "zone": "chain_frozen",
+      "zone": "chain_deferred_pending_phase_b",
       "category": "timestamp_write",
       "sensitivity": "無害",
       "rationale": "純寫入時戳（trained_at/fetched_at/DEFAULT），不參與日期界線比較",
@@ -1540,7 +1645,7 @@
     {
       "file": "src/cpbl/ingest/game_source_revisions.py",
       "line": 135,
-      "zone": "chain_frozen",
+      "zone": "chain_deferred_pending_phase_b",
       "category": "timestamp_write",
       "sensitivity": "無害",
       "rationale": "純寫入時戳（trained_at/fetched_at/DEFAULT），不參與日期界線比較",
@@ -1549,7 +1654,7 @@
     {
       "file": "src/cpbl/ingest/game_tm_shadow.py",
       "line": 260,
-      "zone": "chain_frozen",
+      "zone": "chain_deferred_pending_phase_b",
       "category": "timestamp_write",
       "sensitivity": "無害",
       "rationale": "純寫入時戳（trained_at/fetched_at/DEFAULT），不參與日期界線比較",
@@ -1558,7 +1663,7 @@
     {
       "file": "src/cpbl/ingest/game_tm_shadow.py",
       "line": 312,
-      "zone": "chain_frozen",
+      "zone": "chain_deferred_pending_phase_b",
       "category": "timestamp_write",
       "sensitivity": "無害",
       "rationale": "純寫入時戳（trained_at/fetched_at/DEFAULT），不參與日期界線比較",
@@ -1567,7 +1672,7 @@
     {
       "file": "src/cpbl/ingest/game_tm_shadow.py",
       "line": 462,
-      "zone": "chain_frozen",
+      "zone": "chain_deferred_pending_phase_b",
       "category": "timestamp_write",
       "sensitivity": "無害",
       "rationale": "純寫入時戳（trained_at/fetched_at/DEFAULT），不參與日期界線比較",
@@ -1576,7 +1681,7 @@
     {
       "file": "src/cpbl/ingest/live_shadow_observer.py",
       "line": 653,
-      "zone": "chain_frozen",
+      "zone": "chain_deferred_pending_phase_b",
       "category": "timestamp_write",
       "sensitivity": "無害",
       "rationale": "純寫入時戳（trained_at/fetched_at/DEFAULT），不參與日期界線比較",
@@ -1585,7 +1690,7 @@
     {
       "file": "src/cpbl/ingest/live_shadow_observer.py",
       "line": 724,
-      "zone": "chain_frozen",
+      "zone": "chain_deferred_pending_phase_b",
       "category": "timestamp_write",
       "sensitivity": "無害",
       "rationale": "純寫入時戳（trained_at/fetched_at/DEFAULT），不參與日期界線比較",
@@ -1594,7 +1699,7 @@
     {
       "file": "src/cpbl/ingest/live_shadow_observer.py",
       "line": 759,
-      "zone": "chain_frozen",
+      "zone": "chain_deferred_pending_phase_b",
       "category": "timestamp_write",
       "sensitivity": "無害",
       "rationale": "純寫入時戳（trained_at/fetched_at/DEFAULT），不參與日期界線比較",
@@ -1603,7 +1708,7 @@
     {
       "file": "src/cpbl/ingest/run_refresh_recent.py",
       "line": 140,
-      "zone": "chain_frozen",
+      "zone": "chain_deferred_pending_phase_b",
       "category": "window_offset",
       "sensitivity": "敏感-中",
       "rationale": "整個視窗連動位移一天",
@@ -1612,7 +1717,7 @@
     {
       "file": "src/cpbl/ingest/splits_calc.py",
       "line": 176,
-      "zone": "chain_frozen",
+      "zone": "chain_deferred_pending_phase_b",
       "category": "upper_bound",
       "sensitivity": "無害-保守",
       "rationale": "UTC 落後只會晚 8 小時納入，永不誤納未來場",
@@ -1621,7 +1726,7 @@
     {
       "file": "src/cpbl/ingest/splits_calc.py",
       "line": 226,
-      "zone": "chain_frozen",
+      "zone": "chain_deferred_pending_phase_b",
       "category": "upper_bound",
       "sensitivity": "無害-保守",
       "rationale": "UTC 落後只會晚 8 小時納入，永不誤納未來場",
@@ -1630,7 +1735,7 @@
     {
       "file": "src/cpbl/ingest/splits_calc.py",
       "line": 585,
-      "zone": "chain_frozen",
+      "zone": "chain_deferred_pending_phase_b",
       "category": "upper_bound",
       "sensitivity": "無害-保守",
       "rationale": "UTC 落後只會晚 8 小時納入，永不誤納未來場",
@@ -1639,7 +1744,7 @@
     {
       "file": "src/cpbl/ingest/splits_calc.py",
       "line": 636,
-      "zone": "chain_frozen",
+      "zone": "chain_deferred_pending_phase_b",
       "category": "upper_bound",
       "sensitivity": "無害-保守",
       "rationale": "UTC 落後只會晚 8 小時納入，永不誤納未來場",
@@ -1648,7 +1753,7 @@
     {
       "file": "src/cpbl/ingest/splits_calc.py",
       "line": 744,
-      "zone": "chain_frozen",
+      "zone": "chain_deferred_pending_phase_b",
       "category": "timestamp_write",
       "sensitivity": "無害",
       "rationale": "純寫入時戳（trained_at/fetched_at/DEFAULT），不參與日期界線比較",
@@ -1657,7 +1762,7 @@
     {
       "file": "src/cpbl/ingest/splits_calc.py",
       "line": 905,
-      "zone": "chain_frozen",
+      "zone": "chain_deferred_pending_phase_b",
       "category": "timestamp_write",
       "sensitivity": "無害",
       "rationale": "純寫入時戳（trained_at/fetched_at/DEFAULT），不參與日期界線比較",
@@ -1674,7 +1779,7 @@
     },
     {
       "file": "src/cpbl/models/train.py",
-      "line": 133,
+      "line": 135,
       "zone": "in_scope",
       "category": "timestamp_write",
       "sensitivity": "無害",
@@ -1683,7 +1788,7 @@
     },
     {
       "file": "src/cpbl/models/train_pitching.py",
-      "line": 154,
+      "line": 156,
       "zone": "in_scope",
       "category": "timestamp_write",
       "sensitivity": "無害",
@@ -1692,7 +1797,7 @@
     },
     {
       "file": "src/cpbl/models/winprob_strength.py",
-      "line": 747,
+      "line": 749,
       "zone": "in_scope",
       "category": "comment_or_string",
       "sensitivity": "說明文字",
@@ -1701,7 +1806,7 @@
     },
     {
       "file": "src/cpbl/models/winprob_strength.py",
-      "line": 993,
+      "line": 996,
       "zone": "in_scope",
       "category": "comment_or_string",
       "sensitivity": "說明文字",
@@ -1710,7 +1815,7 @@
     },
     {
       "file": "src/cpbl/models/winprob_strength.py",
-      "line": 1041,
+      "line": 1058,
       "zone": "in_scope",
       "category": "comment_or_string",
       "sensitivity": "說明文字",
@@ -1719,7 +1824,7 @@
     },
     {
       "file": "src/cpbl/models/winprob_strength.py",
-      "line": 1058,
+      "line": 1075,
       "zone": "in_scope",
       "category": "comment_or_string",
       "sensitivity": "說明文字",
@@ -1728,7 +1833,7 @@
     },
     {
       "file": "src/cpbl/models/winprob_strength.py",
-      "line": 1114,
+      "line": 1136,
       "zone": "in_scope",
       "category": "timestamp_write",
       "sensitivity": "無害",
@@ -1737,7 +1842,7 @@
     },
     {
       "file": "src/cpbl/models/winprob_val.py",
-      "line": 323,
+      "line": 456,
       "zone": "in_scope",
       "category": "upper_bound",
       "sensitivity": "無害-保守",
@@ -1746,7 +1851,7 @@
     },
     {
       "file": "src/cpbl/models/winprob_val.py",
-      "line": 490,
+      "line": 951,
       "zone": "in_scope",
       "category": "upper_bound",
       "sensitivity": "無害-保守",
@@ -1853,6 +1958,15 @@
       "code": "assert \"bio_updated_at = now()\" in sql"
     },
     {
+      "file": "tests/test_box_revisions.py",
+      "line": 407,
+      "zone": "tests",
+      "category": "already_taipei",
+      "sensitivity": "已修正",
+      "rationale": "已用 Asia/Taipei 模式",
+      "code": "\"SELECT (now() AT TIME ZONE 'Asia/Taipei')::date - %s::date\","
+    },
+    {
       "file": "tests/test_completion.py",
       "line": 34,
       "zone": "tests",
@@ -1872,34 +1986,97 @@
     },
     {
       "file": "tests/test_completion_evidence.py",
-      "line": 77,
+      "line": 23,
       "zone": "tests",
       "category": "already_taipei",
       "sensitivity": "已修正",
       "rationale": "已用 Asia/Taipei 模式",
-      "code": "_TAIPEI_TODAY = \"(now() AT TIME ZONE 'Asia/Taipei')::date\""
+      "code": "TAIPEI_TODAY_SQL,"
     },
     {
       "file": "tests/test_completion_evidence.py",
-      "line": 216,
+      "line": 34,
       "zone": "tests",
-      "category": "upper_bound",
-      "sensitivity": "無害-保守",
-      "rationale": "UTC 落後只會晚 8 小時納入，永不誤納未來場",
-      "code": "WHERE g.home_score + g.away_score = 0 AND g.game_date <= CURRENT_DATE"
+      "category": "already_taipei",
+      "sensitivity": "已修正",
+      "rationale": "已用 Asia/Taipei 模式",
+      "code": "pytest.param(TAIPEI_TODAY_SQL, id=\"as_of=Taipei\"),"
     },
     {
       "file": "tests/test_completion_evidence.py",
-      "line": 223,
+      "line": 87,
       "zone": "tests",
-      "category": "upper_bound",
-      "sensitivity": "無害-保守",
-      "rationale": "UTC 落後只會晚 8 小時納入，永不誤納未來場",
-      "code": "WHERE g.home_score + g.away_score = 0 AND g.game_date <= CURRENT_DATE"
+      "category": "already_taipei",
+      "sensitivity": "已修正",
+      "rationale": "已用 Asia/Taipei 模式",
+      "code": "_TAIPEI_TODAY = TAIPEI_TODAY_SQL"
     },
     {
       "file": "tests/test_completion_evidence.py",
-      "line": 310,
+      "line": 148,
+      "zone": "tests",
+      "category": "already_taipei",
+      "sensitivity": "已修正",
+      "rationale": "已用 Asia/Taipei 模式",
+      "code": "tpe = _game_set(completed_games_sql_with_evidence(\"games\", TAIPEI_TODAY_SQL))"
+    },
+    {
+      "file": "tests/test_completion_evidence.py",
+      "line": 154,
+      "zone": "tests",
+      "category": "already_taipei",
+      "sensitivity": "已修正",
+      "rationale": "已用 Asia/Taipei 模式",
+      "code": "f\"games.game_date > {UTC_TODAY_SQL} AND games.game_date <= {TAIPEI_TODAY_SQL}\")"
+    },
+    {
+      "file": "tests/test_completion_evidence.py",
+      "line": 171,
+      "zone": "tests",
+      "category": "already_taipei",
+      "sensitivity": "已修正",
+      "rationale": "已用 Asia/Taipei 模式",
+      "code": "assert TAIPEI_TODAY_SQL in completed_games_sql_with_evidence(\"g\")"
+    },
+    {
+      "file": "tests/test_completion_evidence.py",
+      "line": 172,
+      "zone": "tests",
+      "category": "already_taipei",
+      "sensitivity": "已修正",
+      "rationale": "已用 Asia/Taipei 模式",
+      "code": "assert UTC_TODAY_SQL != TAIPEI_TODAY_SQL"
+    },
+    {
+      "file": "tests/test_completion_evidence.py",
+      "line": 290,
+      "zone": "tests",
+      "category": "already_taipei",
+      "sensitivity": "已修正",
+      "rationale": "已用 Asia/Taipei 模式",
+      "code": "cond = completed_games_sql_with_evidence(\"g\", TAIPEI_TODAY_SQL)"
+    },
+    {
+      "file": "tests/test_completion_evidence.py",
+      "line": 293,
+      "zone": "tests",
+      "category": "already_taipei",
+      "sensitivity": "已修正",
+      "rationale": "已用 Asia/Taipei 模式",
+      "code": "WHERE g.home_score + g.away_score = 0 AND g.game_date <= {TAIPEI_TODAY_SQL}"
+    },
+    {
+      "file": "tests/test_completion_evidence.py",
+      "line": 300,
+      "zone": "tests",
+      "category": "already_taipei",
+      "sensitivity": "已修正",
+      "rationale": "已用 Asia/Taipei 模式",
+      "code": "WHERE g.home_score + g.away_score = 0 AND g.game_date <= {TAIPEI_TODAY_SQL}"
+    },
+    {
+      "file": "tests/test_completion_evidence.py",
+      "line": 387,
       "zone": "tests",
       "category": "already_taipei",
       "sensitivity": "已修正",
@@ -1908,12 +2085,30 @@
     },
     {
       "file": "tests/test_completion_evidence.py",
-      "line": 318,
+      "line": 395,
       "zone": "tests",
       "category": "already_taipei",
       "sensitivity": "已修正",
       "rationale": "已用 Asia/Taipei 模式",
       "code": "WHERE g.game_date > (now() AT TIME ZONE 'Asia/Taipei')::date AND ({cond})"
+    },
+    {
+      "file": "tests/test_incomplete_box_ingest.py",
+      "line": 52,
+      "zone": "tests",
+      "category": "upper_bound",
+      "sensitivity": "無害-保守",
+      "rationale": "UTC 落後只會晚 8 小時納入，永不誤納未來場",
+      "code": "assert \"game_date <= CURRENT_DATE\" in cursor.sql"
+    },
+    {
+      "file": "tests/test_incomplete_box_ingest.py",
+      "line": 62,
+      "zone": "tests",
+      "category": "upper_bound",
+      "sensitivity": "無害-保守",
+      "rationale": "UTC 落後只會晚 8 小時納入，永不誤納未來場",
+      "code": "assert \"game_date <= CURRENT_DATE\" in cursor.sql"
     },
     {
       "file": "tests/test_refresh_pa_daily.py",
@@ -2052,7 +2247,7 @@
     },
     {
       "file": "tests/test_winprob_strength.py",
-      "line": 913,
+      "line": 918,
       "zone": "tests",
       "category": "comment_or_string",
       "sensitivity": "說明文字",

--- a/docs/research/DOC-G4-FREEZE-STALE1/README.md
+++ b/docs/research/DOC-G4-FREEZE-STALE1/README.md
@@ -1,0 +1,13 @@
+# DOC-G4-FREEZE-STALE1 掃描 artifact
+
+`scan.json` 是全庫 G4 觀測凍結相關陳述的逐行盤點與判定；由同目錄的
+`scan_g4_freeze.py` 產生，禁止手改。
+
+```bash
+uv run python docs/research/DOC-G4-FREEZE-STALE1/scan_g4_freeze.py
+uv run python docs/research/DOC-G4-FREEZE-STALE1/scan_g4_freeze.py --verify
+```
+
+掃描涵蓋所有 Git 追蹤檔，但排除本 artifact 目錄以避免掃描器與輸出對自身產生自指。
+每筆命中皆有 `disposition` 與 `rationale`；`needs_pm_followup` 表示本卡寫入集外、需由
+PM 判定是否另開卡的現行用詞。

--- a/docs/research/DOC-G4-FREEZE-STALE1/scan.json
+++ b/docs/research/DOC-G4-FREEZE-STALE1/scan.json
@@ -1,0 +1,323 @@
+{
+  "generated_at": "2026-08-09T00:22:28+08:00",
+  "scope": "所有 Git 追蹤檔案，排除本 artifact 目錄以避免自指。",
+  "patterns": [
+    "G4.{0,120}(凍結|收窗後|觀測窗)|(凍結|收窗後).{0,120}G4|G4.*freeze|freeze.*G4"
+  ],
+  "total_hits": 42,
+  "by_disposition": {
+    "active_data_exception": 2,
+    "active_scope_exclusion": 3,
+    "historical_artifact": 24,
+    "historical_task_record": 2,
+    "needs_pm_followup": 1,
+    "resolved_gate3_fact": 2,
+    "resolved_gate3_with_phase_b_dependency": 2,
+    "task_context": 6
+  },
+  "needs_pm_followup": [
+    {
+      "file": "tests/test_box_revisions_deep_layer.py",
+      "line": 113,
+      "text": "（G4 觀測凍結、且卡面要求「深度層與每日窗分開，不要把每日窗撐大」）。",
+      "disposition": "needs_pm_followup",
+      "rationale": "未能自動歸入歷史紀錄、Gate 3 已解除事實、Phase B 依賴或資料例外。"
+    }
+  ],
+  "hits": [
+    {
+      "file": "docs/AI_WORKFLOW.md",
+      "line": 26,
+      "text": "11. **派工包六條**：範圍外發現回報 PM 禁 spawn_task／不停等背景通知／禁 `gh pr update-branch`／詭異數據人工判讀＋新聞佐證四約束（僅定性、官方數值權威、URL＋日期、第三方泛化）／trailer 連續單一區塊／CLI 探索紅線（[`dispatch-package.md`](../.ai-workflow/templates/dispatch-package.md)）。**本專案當前仍有副作用的 CLI 入口：`cpbl-refresh-recent`（連 `--help` 都會觸發每日鏈）；此限制仍在，但 Gate 3 已於 2026-08-03 提前收窗並解除 G4 凍結，修正 `--help` 行為的前置條件已滿足**（[`INGEST-GAME-TM-REFACTOR1-G4.md`](tasks/INGEST-GAME-TM-REFACTOR1-G4.md) L21、L362）。",
+      "disposition": "resolved_gate3_fact",
+      "rationale": "明示 Gate 3 已收窗並解除觀測凍結。"
+    },
+    {
+      "file": "docs/design/GAME-PAGE-THREE-STATES.md",
+      "line": 16,
+      "text": "- 紅線沿用（2026-08-06 修訂）：WP 機率**水平值**不作敘事宣稱，**\\|ΔWP\\| 序數選取與變化量顯示為可**（brief 非目標欄兩次修訂；守門條件見 §4.2）；正式文案**禁球迷暱稱**（暱稱僅限賽況頁焦點區既有用法）；`/api/info` 契約不動；每日鏈與 G4 凍結檔不動；API 唯讀。",
+      "disposition": "active_scope_exclusion",
+      "rationale": "不動逐球 writer 的範圍約束仍由 #53 資源佔用支撐；術語待其 owner 收斂。"
+    },
+    {
+      "file": "docs/design/GAME-PAGE-THREE-STATES.md",
+      "line": 205,
+      "text": "- **不動** `pa_build.py`（G4 凍結期外仍屬 canonical builder，本卡只 import 其純函式）。",
+      "disposition": "active_scope_exclusion",
+      "rationale": "不動逐球 writer 的範圍約束仍由 #53 資源佔用支撐；術語待其 owner 收斂。"
+    },
+    {
+      "file": "docs/research/DEV-CLI-HELP-GUARD1/audit_cli_help.py",
+      "line": 65,
+      "text": "# 這些檔案由 INGEST-GAME-TM-REFACTOR1-G4 觀測凍結，本卡只盤點不修改。",
+      "disposition": "historical_artifact",
+      "rationale": "已結案 audit 的當時寫入邊界與產出，不改寫歷史證據。"
+    },
+    {
+      "file": "docs/research/DEV-CLI-HELP-GUARD1/audit_cli_help.py",
+      "line": 397,
+      "text": "\"🧊 ＝ INGEST-GAME-TM-REFACTOR1-G4 觀測凍結檔，本卡只盤點不修改。\",",
+      "disposition": "historical_artifact",
+      "rationale": "已結案 audit 的當時寫入邊界與產出，不改寫歷史證據。"
+    },
+    {
+      "file": "docs/research/DEV-CLI-HELP-GUARD1/audit_cli_help.py",
+      "line": 404,
+      "text": "\"DEV-CLI-HELP-GUARD1 的寫入集只有 `src/cpbl/ingest/`（扣掉兩個 G4 凍結檔）、\",",
+      "disposition": "historical_artifact",
+      "rationale": "已結案 audit 的當時寫入邊界與產出，不改寫歷史證據。"
+    },
+    {
+      "file": "docs/research/DEV-CLI-HELP-GUARD1/audit_cli_help.py",
+      "line": 408,
+      "text": "\"- 🧊 `cpbl-refresh-recent` — G4 觀測凍結檔，明文排除（`git diff` 零 diff 為驗收條件）。\",",
+      "disposition": "historical_artifact",
+      "rationale": "已結案 audit 的當時寫入邊界與產出，不改寫歷史證據。"
+    },
+    {
+      "file": "docs/research/DEV-CLI-HELP-GUARD1/audit_cli_help.py",
+      "line": 422,
+      "text": "+ (\"　**（G4 凍結檔，本卡不修）**\" if e.frozen else \"\"))",
+      "disposition": "historical_artifact",
+      "rationale": "已結案 audit 的當時寫入邊界與產出，不改寫歷史證據。"
+    },
+    {
+      "file": "docs/research/DEV-CLI-HELP-GUARD1/cli-help-audit-before.md",
+      "line": 86,
+      "text": "🧊 ＝ INGEST-GAME-TM-REFACTOR1-G4 觀測凍結檔，本卡只盤點不修改。",
+      "disposition": "historical_artifact",
+      "rationale": "已結案 audit 的當時寫入邊界與產出，不改寫歷史證據。"
+    },
+    {
+      "file": "docs/research/DEV-CLI-HELP-GUARD1/cli-help-audit-before.md",
+      "line": 93,
+      "text": "DEV-CLI-HELP-GUARD1 的寫入集只有 `src/cpbl/ingest/`（扣掉兩個 G4 凍結檔）、",
+      "disposition": "historical_artifact",
+      "rationale": "已結案 audit 的當時寫入邊界與產出，不改寫歷史證據。"
+    },
+    {
+      "file": "docs/research/DEV-CLI-HELP-GUARD1/cli-help-audit-before.md",
+      "line": 97,
+      "text": "- 🧊 `cpbl-refresh-recent` — G4 觀測凍結檔，明文排除（`git diff` 零 diff 為驗收條件）。",
+      "disposition": "historical_artifact",
+      "rationale": "已結案 audit 的當時寫入邊界與產出，不改寫歷史證據。"
+    },
+    {
+      "file": "docs/research/DEV-CLI-HELP-GUARD1/cli-help-audit-before.md",
+      "line": 112,
+      "text": "- `cpbl-refresh-recent` — 主流程觸及 cpbl.db.migrate　**（G4 凍結檔，本卡不修）**",
+      "disposition": "historical_artifact",
+      "rationale": "已結案 audit 的當時寫入邊界與產出，不改寫歷史證據。"
+    },
+    {
+      "file": "docs/research/DEV-CLI-HELP-GUARD1/cli-help-audit.md",
+      "line": 86,
+      "text": "🧊 ＝ INGEST-GAME-TM-REFACTOR1-G4 觀測凍結檔，本卡只盤點不修改。",
+      "disposition": "historical_artifact",
+      "rationale": "已結案 audit 的當時寫入邊界與產出，不改寫歷史證據。"
+    },
+    {
+      "file": "docs/research/DEV-CLI-HELP-GUARD1/cli-help-audit.md",
+      "line": 93,
+      "text": "DEV-CLI-HELP-GUARD1 的寫入集只有 `src/cpbl/ingest/`（扣掉兩個 G4 凍結檔）、",
+      "disposition": "historical_artifact",
+      "rationale": "已結案 audit 的當時寫入邊界與產出，不改寫歷史證據。"
+    },
+    {
+      "file": "docs/research/DEV-CLI-HELP-GUARD1/cli-help-audit.md",
+      "line": 97,
+      "text": "- 🧊 `cpbl-refresh-recent` — G4 觀測凍結檔，明文排除（`git diff` 零 diff 為驗收條件）。",
+      "disposition": "historical_artifact",
+      "rationale": "已結案 audit 的當時寫入邊界與產出，不改寫歷史證據。"
+    },
+    {
+      "file": "docs/research/DEV-CLI-HELP-GUARD1/cli-help-audit.md",
+      "line": 110,
+      "text": "- `cpbl-refresh-recent` — 主流程觸及 cpbl.db.migrate　**（G4 凍結檔，本卡不修）**",
+      "disposition": "historical_artifact",
+      "rationale": "已結案 audit 的當時寫入邊界與產出，不改寫歷史證據。"
+    },
+    {
+      "file": "docs/research/DEV-CLI-HELP-GUARD2/cli-help-audit-before.md",
+      "line": 86,
+      "text": "🧊 ＝ INGEST-GAME-TM-REFACTOR1-G4 觀測凍結檔，本卡只盤點不修改。",
+      "disposition": "historical_artifact",
+      "rationale": "已結案 audit 的當時寫入邊界與產出，不改寫歷史證據。"
+    },
+    {
+      "file": "docs/research/DEV-CLI-HELP-GUARD2/cli-help-audit-before.md",
+      "line": 93,
+      "text": "DEV-CLI-HELP-GUARD1 的寫入集只有 `src/cpbl/ingest/`（扣掉兩個 G4 凍結檔）、",
+      "disposition": "historical_artifact",
+      "rationale": "已結案 audit 的當時寫入邊界與產出，不改寫歷史證據。"
+    },
+    {
+      "file": "docs/research/DEV-CLI-HELP-GUARD2/cli-help-audit-before.md",
+      "line": 97,
+      "text": "- 🧊 `cpbl-refresh-recent` — G4 觀測凍結檔，明文排除（`git diff` 零 diff 為驗收條件）。",
+      "disposition": "historical_artifact",
+      "rationale": "已結案 audit 的當時寫入邊界與產出，不改寫歷史證據。"
+    },
+    {
+      "file": "docs/research/DEV-CLI-HELP-GUARD2/cli-help-audit-before.md",
+      "line": 110,
+      "text": "- `cpbl-refresh-recent` — 主流程觸及 cpbl.db.migrate　**（G4 凍結檔，本卡不修）**",
+      "disposition": "historical_artifact",
+      "rationale": "已結案 audit 的當時寫入邊界與產出，不改寫歷史證據。"
+    },
+    {
+      "file": "docs/research/DEV-CLI-HELP-GUARD2/cli-help-audit.md",
+      "line": 86,
+      "text": "🧊 ＝ INGEST-GAME-TM-REFACTOR1-G4 觀測凍結檔，本卡只盤點不修改。",
+      "disposition": "historical_artifact",
+      "rationale": "已結案 audit 的當時寫入邊界與產出，不改寫歷史證據。"
+    },
+    {
+      "file": "docs/research/DEV-CLI-HELP-GUARD2/cli-help-audit.md",
+      "line": 93,
+      "text": "DEV-CLI-HELP-GUARD1 的寫入集只有 `src/cpbl/ingest/`（扣掉兩個 G4 凍結檔）、",
+      "disposition": "historical_artifact",
+      "rationale": "已結案 audit 的當時寫入邊界與產出，不改寫歷史證據。"
+    },
+    {
+      "file": "docs/research/DEV-CLI-HELP-GUARD2/cli-help-audit.md",
+      "line": 97,
+      "text": "- 🧊 `cpbl-refresh-recent` — G4 觀測凍結檔，明文排除（`git diff` 零 diff 為驗收條件）。",
+      "disposition": "historical_artifact",
+      "rationale": "已結案 audit 的當時寫入邊界與產出，不改寫歷史證據。"
+    },
+    {
+      "file": "docs/research/DEV-CLI-HELP-GUARD2/cli-help-audit.md",
+      "line": 107,
+      "text": "- `cpbl-refresh-recent` — 主流程觸及 cpbl.db.migrate　**（G4 凍結檔，本卡不修）**",
+      "disposition": "historical_artifact",
+      "rationale": "已結案 audit 的當時寫入邊界與產出，不改寫歷史證據。"
+    },
+    {
+      "file": "docs/research/INIT-GAME-RECAP/spike-report.md",
+      "line": 146,
+      "text": "→ **PASS**。單場 recap 完全可在 request 內算完，無需物化表、無需進每日鏈（G4 凍結無涉）。",
+      "disposition": "historical_artifact",
+      "rationale": "已結案 research／spike 的當時範圍說明，不改寫歷史證據。"
+    },
+    {
+      "file": "docs/research/INIT-GAME-RECAP_DISCOVERY-BRIEF.md",
+      "line": 50,
+      "text": "- **全即時算、每日鏈零改動**（G4 凍結不受影響）：PA 序列 × `run_expectancy` 矩陣查表",
+      "disposition": "historical_artifact",
+      "rationale": "已結案 research／spike 的當時範圍說明，不改寫歷史證據。"
+    },
+    {
+      "file": "docs/research/INIT-GAME-RECAP_DISCOVERY-BRIEF.md",
+      "line": 64,
+      "text": "DB writer、零鏈改動＝G4 凍結無涉。原分級渲染降級為極端 fallback（snapshot",
+      "disposition": "historical_artifact",
+      "rationale": "已結案 research／spike 的當時範圍說明，不改寫歷史證據。"
+    },
+    {
+      "file": "docs/tasks/DATA-RE24-GHOST-RUNNER1.md",
+      "line": 18,
+      "text": "- [ ] 回歸：未歸類=0 釘成測試（spike 建議）；G4 凍結檔零 diff",
+      "disposition": "historical_task_record",
+      "rationale": "已結案卡的當時驗收或資源邊界，保留歷史紀錄。"
+    },
+    {
+      "file": "docs/tasks/DATA-TZ-BOUNDARY1.md",
+      "line": 19,
+      "text": "- [ ] 鏈端（`src/cpbl/ingest/`）用點：#113 已將 `run_refresh_recent.py` 的完成場判準改為共用 `completed_games_sql()`，故不再是「只記錄不改」；但該 helper 預設仍為 UTC，且 `cpbl_pitch_tracking.py` 仍有原始 `CURRENT_DATE` 用點。兩者的 Asia/Taipei 日界切換**明確依賴 #53 G4 Phase B 完成後**的另行授權鏈端實作卡；Gate 3 已於 2026-08-03 提前收窗並解除凍結，不能再以 Gate 3 觀測凍結作為延後理由（[`INGEST-GAME-TM-REFACTOR1-G4.md`](INGEST-GAME-TM-REFACTOR1-G4.md) L21、L362）。",
+      "disposition": "resolved_gate3_with_phase_b_dependency",
+      "rationale": "Gate 3 觀測凍結已解除；鏈端後續仍依賴尚未完成的 #53 G4 Phase B。"
+    },
+    {
+      "file": "docs/tasks/DEV-CLI-HELP-GUARD1.md",
+      "line": 21,
+      "text": "- [ ] G4 凍結檔零 diff：run_refresh_recent.py、cpbl_pitch_tracking.py（在資源宣告 ingest/ 內但明文排除）",
+      "disposition": "historical_task_record",
+      "rationale": "已結案卡的當時驗收或資源邊界，保留歷史紀錄。"
+    },
+    {
+      "file": "docs/tasks/DOC-G4-FREEZE-STALE1.md",
+      "line": 1,
+      "text": "# DOC-G4-FREEZE-STALE1 修正 G4 觀測凍結過期陳述與可重跑掃描　〔T2〕",
+      "disposition": "task_context",
+      "rationale": "本卡問題與驗收的描述，不是現行凍結宣稱。"
+    },
+    {
+      "file": "docs/tasks/DOC-G4-FREEZE-STALE1.md",
+      "line": 6,
+      "text": "- DB：db_scope=none　資源：`scripts/data_tz_boundary1.py`、`src/cpbl/completion.py`、`tests/test_tz_boundary.py`、`tests/test_cli_help_guard.py`、`docs/tasks/DEV-CLI-HELP-GUARD2.md`、`docs/tasks/DATA-TZ-BOUNDARY1.md`、`docs/research/DOC-G4-FREEZE-STALE1/`",
+      "disposition": "task_context",
+      "rationale": "本卡問題與驗收的描述，不是現行凍結宣稱。"
+    },
+    {
+      "file": "docs/tasks/DOC-G4-FREEZE-STALE1.md",
+      "line": 9,
+      "text": "current-state 見對應 GitHub Issue／Project item（卡ID：DOC-G4-FREEZE-STALE1），不重複於此檔。",
+      "disposition": "task_context",
+      "rationale": "本卡問題與驗收的描述，不是現行凍結宣稱。"
+    },
+    {
+      "file": "docs/tasks/DOC-G4-FREEZE-STALE1.md",
+      "line": 13,
+      "text": "- **痛點**：docs/AI_WORKFLOW.md:26 寫「G4 凍結中，收窗後修」、docs/tasks/DATA-TZ-BOUNDARY1.md:19 寫「鏈端只記錄不改——G4 觀測凍結」，但權威來源 docs/tasks/INGEST-GAME-TM-REFACTOR1-G4.md L21/L362 明載 Gate 3 已於 2026-08-03（第 9 天、run_id=14）依需求方裁示提前收窗、凍結範圍解除。文件與權威來源互相矛盾，讀者無從判斷哪一份為準；#113 的執行者即因此在動鏈端碼時缺少對齊依據，由查核者以 DATA-INCOMPLETE-BOX-INGEST1-R1-02 指出",
+      "disposition": "task_context",
+      "rationale": "本卡問題與驗收的描述，不是現行凍結宣稱。"
+    },
+    {
+      "file": "docs/tasks/DOC-G4-FREEZE-STALE1.md",
+      "line": 20,
+      "text": "- [ ] 全庫掃一次同類過期陳述：grep 「G4」「凍結」「收窗後」等詞，把命中結果逐條判定為仍有效／已過期，artifact 由指令輸出產生而非人工列舉",
+      "disposition": "task_context",
+      "rationale": "本卡問題與驗收的描述，不是現行凍結宣稱。"
+    },
+    {
+      "file": "docs/tasks/DOC-G4-FREEZE-STALE1.md",
+      "line": 23,
+      "text": "- [ ] 全庫掃描 artifact 與可重跑指令落在 `docs/research/DOC-G4-FREEZE-STALE1/`，每個命中都帶判定與理由",
+      "disposition": "task_context",
+      "rationale": "本卡問題與驗收的描述，不是現行凍結宣稱。"
+    },
+    {
+      "file": "docs/tasks/INGEST-LIVE-RECONCILE1.md",
+      "line": 36,
+      "text": "1. Gate 3 觀測窗已於 2026-08-03 收窗、凍結解除，本條的觀測隔離義務**已履行完畢**。改寫正式 `pitch_tracking` writer 的權責自此歸 `INGEST-GAME-TM-REFACTOR1-G4`：本卡在該卡完成 cutover 並取得 production sign-off 前，仍不得改動逐球正式 writer，亦不得把 provisional 資料併入其對帳母體。〔writer 單一權責〕",
+      "disposition": "resolved_gate3_fact",
+      "rationale": "明示 Gate 3 已收窗並解除觀測凍結。"
+    },
+    {
+      "file": "scripts/data_tz_boundary1.py",
+      "line": 38,
+      "text": "# 鏈端時區切換須待 #53 G4 Phase B 後另卡授權；不是已解除的 Gate 3 觀測凍結。",
+      "disposition": "resolved_gate3_with_phase_b_dependency",
+      "rationale": "Gate 3 觀測凍結已解除；鏈端後續仍依賴尚未完成的 #53 G4 Phase B。"
+    },
+    {
+      "file": "scripts/g4_gate_report.py",
+      "line": 1,
+      "text": "\"\"\"INGEST-GAME-TM-REFACTOR1-G4 Phase A：gate 判定與凍結例外後的紅線 1 複判（唯讀）。",
+      "disposition": "active_data_exception",
+      "rationale": "需求方 2026-08-05 裁定的資料例外清單，非 Gate 3 觀測凍結。"
+    },
+    {
+      "file": "src/cpbl/ingest/cpbl_pitch_tracking.py",
+      "line": 45,
+      "text": "# ── 凍結例外清單（INGEST-GAME-TM-REFACTOR1-G4 紅線 1；需求方 2026-08-05 裁定）────────",
+      "disposition": "active_data_exception",
+      "rationale": "需求方 2026-08-05 裁定的資料例外清單，非 Gate 3 觀測凍結。"
+    },
+    {
+      "file": "src/cpbl/models/pa_facts.py",
+      "line": 37,
+      "text": "紅線：唯讀（不寫任何表）；不改 ``pa_build``／每日鏈／G4 凍結檔。",
+      "disposition": "active_scope_exclusion",
+      "rationale": "不動逐球 writer 的範圍約束仍由 #53 資源佔用支撐；術語待其 owner 收斂。"
+    },
+    {
+      "file": "tests/test_box_revisions_deep_layer.py",
+      "line": 113,
+      "text": "（G4 觀測凍結、且卡面要求「深度層與每日窗分開，不要把每日窗撐大」）。",
+      "disposition": "needs_pm_followup",
+      "rationale": "未能自動歸入歷史紀錄、Gate 3 已解除事實、Phase B 依賴或資料例外。"
+    }
+  ]
+}

--- a/docs/research/DOC-G4-FREEZE-STALE1/scan_g4_freeze.py
+++ b/docs/research/DOC-G4-FREEZE-STALE1/scan_g4_freeze.py
@@ -1,0 +1,127 @@
+"""DOC-G4-FREEZE-STALE1：全庫 G4 觀測凍結陳述盤點（唯讀）。
+
+    uv run python docs/research/DOC-G4-FREEZE-STALE1/scan_g4_freeze.py
+    uv run python docs/research/DOC-G4-FREEZE-STALE1/scan_g4_freeze.py --verify
+
+輸出逐行保留命中與機器判定。輸出目錄本身不納入掃描，避免 artifact／掃描器對自身的
+「G4／凍結」說明造成不穩定自指；其餘受 Git 追蹤檔案全部納入。
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import subprocess
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+ARTIFACT_DIR = Path("docs/research/DOC-G4-FREEZE-STALE1")
+DEFAULT_OUT = ARTIFACT_DIR / "scan.json"
+CANDIDATE_RE = re.compile(
+    r"G4.{0,120}(凍結|收窗後|觀測窗)|(凍結|收窗後).{0,120}G4|G4.*freeze|freeze.*G4",
+    re.IGNORECASE,
+)
+
+
+def _tracked_files() -> list[str]:
+    files = subprocess.run(
+        ["git", "ls-files"], capture_output=True, text=True, check=True
+    ).stdout.splitlines()
+    return [path for path in files if not path.startswith(f"{ARTIFACT_DIR}/")]
+
+
+def _classify(path: str, text: str) -> tuple[str, str]:
+    """回傳該命中現在的治理意義；不把所有「凍結」一律當成已解除的 Gate 3。"""
+    if path.startswith("docs/research/DEV-CLI-HELP-GUARD"):
+        return "historical_artifact", "已結案 audit 的當時寫入邊界與產出，不改寫歷史證據。"
+    if path.startswith("docs/research/INIT-GAME-RECAP"):
+        return "historical_artifact", "已結案 research／spike 的當時範圍說明，不改寫歷史證據。"
+    if path == "docs/tasks/DOC-G4-FREEZE-STALE1.md":
+        return "task_context", "本卡問題與驗收的描述，不是現行凍結宣稱。"
+    if ("Phase B" in text or "#53" in text) and ("解除" in text or "提前收窗" in text):
+        return (
+            "resolved_gate3_with_phase_b_dependency",
+            "Gate 3 觀測凍結已解除；鏈端後續仍依賴尚未完成的 #53 G4 Phase B。",
+        )
+    if "凍結例外" in text:
+        return "active_data_exception", "需求方 2026-08-05 裁定的資料例外清單，非 Gate 3 觀測凍結。"
+    if "解除" in text or "提前收窗" in text:
+        return "resolved_gate3_fact", "明示 Gate 3 已收窗並解除觀測凍結。"
+    if "Phase B" in text or "#53" in text:
+        return "active_phase_b_dependency", "#53 G4 Phase B 尚未完成，屬目前的資源／實作依賴。"
+    if path.startswith("docs/archive/") or path in {
+        "docs/tasks/DEV-CLI-HELP-GUARD1.md",
+        "docs/tasks/DATA-RE24-GHOST-RUNNER1.md",
+    }:
+        return "historical_task_record", "已結案卡的當時驗收或資源邊界，保留歷史紀錄。"
+    if path in {
+        "docs/design/GAME-PAGE-THREE-STATES.md",
+        "src/cpbl/models/pa_facts.py",
+    }:
+        return "active_scope_exclusion", "不動逐球 writer 的範圍約束仍由 #53 資源佔用支撐；術語待其 owner 收斂。"
+    return "needs_pm_followup", "未能自動歸入歷史紀錄、Gate 3 已解除事實、Phase B 依賴或資料例外。"
+
+
+def scan() -> dict[str, Any]:
+    hits = []
+    for path in _tracked_files():
+        try:
+            lines = Path(path).read_text(encoding="utf-8").splitlines()
+        except (OSError, UnicodeDecodeError):
+            continue
+        for line_no, line in enumerate(lines, 1):
+            if not CANDIDATE_RE.search(line):
+                continue
+            disposition, rationale = _classify(path, line)
+            hits.append({
+                "file": path,
+                "line": line_no,
+                "text": line.strip(),
+                "disposition": disposition,
+                "rationale": rationale,
+            })
+    counts: dict[str, int] = {}
+    for hit in hits:
+        counts[hit["disposition"]] = counts.get(hit["disposition"], 0) + 1
+    return {
+        "generated_at": datetime.now(UTC).astimezone().isoformat(timespec="seconds"),
+        "scope": "所有 Git 追蹤檔案，排除本 artifact 目錄以避免自指。",
+        "patterns": [CANDIDATE_RE.pattern],
+        "total_hits": len(hits),
+        "by_disposition": dict(sorted(counts.items())),
+        "needs_pm_followup": [hit for hit in hits if hit["disposition"] == "needs_pm_followup"],
+        "hits": hits,
+    }
+
+
+def _write(payload: dict[str, Any], out: Path) -> None:
+    out.parent.mkdir(parents=True, exist_ok=True)
+    out.write_text(json.dumps(payload, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+    print(f"written: {out} ({len(payload['hits'])} hits)")
+
+
+def _verify(out: Path) -> None:
+    stored = json.loads(out.read_text(encoding="utf-8"))
+    fresh = scan()
+    stable = ({k: v for k, v in stored.items() if k != "generated_at"}
+              == {k: v for k, v in fresh.items() if k != "generated_at"})
+    print(json.dumps({"artifact": str(out), "stable": stable}, ensure_ascii=False))
+    if not stable:
+        raise SystemExit("artifact 與目前 HEAD 樹不一致；請先重產再查核")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--out", type=Path, default=DEFAULT_OUT)
+    parser.add_argument("--verify", action="store_true")
+    args = parser.parse_args()
+    if args.verify:
+        _verify(args.out)
+    else:
+        _write(scan(), args.out)
+
+
+if __name__ == "__main__":
+    main()

--- a/docs/tasks/DATA-TZ-BOUNDARY1.md
+++ b/docs/tasks/DATA-TZ-BOUNDARY1.md
@@ -14,9 +14,9 @@
 
 ## 驗收條件
 
-- [ ] 全庫 SQL 盤點 CURRENT_DATE/CURRENT_TIMESTAMP/now() 日期界線用點（artifact 由指令產生），逐點分類：語意敏感／無害／鏈端凍結
+- [ ] 全庫 SQL 盤點 CURRENT_DATE/CURRENT_TIMESTAMP/now() 日期界線用點（artifact 由指令產生），逐點分類：語意敏感／無害／鏈端待 #53 G4 Phase B
 - [ ] 語意敏感點改 (now() AT TIME ZONE 'Asia/Taipei')::date（沿 completion.py helper 模式）；C12 精確等值用點修復＋回歸
-- [ ] 鏈端（`src/cpbl/ingest/`）用點：#113 已將 `run_refresh_recent.py` 的完成場判準改為共用 `completed_games_sql()`，故不再是「只記錄不改」；但該 helper 預設仍為 UTC，且 `cpbl_pitch_tracking.py` 仍有原始 `CURRENT_DATE` 用點。兩者的 Asia/Taipei 日界切換須以另行授權的鏈端實作卡處理；Gate 3 已於 2026-08-03 提前收窗並解除 G4 凍結，不能再以凍結作為延後理由（[`INGEST-GAME-TM-REFACTOR1-G4.md`](INGEST-GAME-TM-REFACTOR1-G4.md) L21、L362）。
+- [ ] 鏈端（`src/cpbl/ingest/`）用點：#113 已將 `run_refresh_recent.py` 的完成場判準改為共用 `completed_games_sql()`，故不再是「只記錄不改」；但該 helper 預設仍為 UTC，且 `cpbl_pitch_tracking.py` 仍有原始 `CURRENT_DATE` 用點。兩者的 Asia/Taipei 日界切換**明確依賴 #53 G4 Phase B 完成後**的另行授權鏈端實作卡；Gate 3 已於 2026-08-03 提前收窗並解除凍結，不能再以 Gate 3 觀測凍結作為延後理由（[`INGEST-GAME-TM-REFACTOR1-G4.md`](INGEST-GAME-TM-REFACTOR1-G4.md) L21、L362）。
 - [ ] 回歸：晨間窗口語意測試不依賴牆鐘（注入時間或斷言 SQL 形態＋DB 端雙時區日期差驗證）
 - [ ] uv run ruff check＋uv run pytest 全綠
 

--- a/docs/tasks/DEV-CLI-HELP-GUARD2.md
+++ b/docs/tasks/DEV-CLI-HELP-GUARD2.md
@@ -4,7 +4,7 @@
 - 執行：待指派　查核：待指派
 - Initiative：—　spec 基線：Issue #91 交付 artifact〈本卡資源邊界〉節（main 18a6146）
 - DB：db_scope=none
-- 服務的原始目標：工程安全——CLI 探索零副作用全覆蓋（僅剩 G4 凍結的 cpbl-refresh-recent 待收窗）
+- 服務的原始目標：工程安全——CLI 探索零副作用全覆蓋（`cpbl-refresh-recent` 仍有副作用；其逐球 writer 由 #53 G4 Phase B 資源佔用，另案處理）
 - owner、worktree、iteration、交付／部署狀態、最後交接、資源宣告與 Log
   current-state 見對應 GitHub Issue／Project item（卡ID：DEV-CLI-HELP-GUARD2），不重複於此檔。
 
@@ -16,8 +16,8 @@
 
 - [ ] 六支入口沿用 cpbl.ingest._cli 護欄：--help/-h 零副作用、非法參數 exit≠0 不執行主流程；既有合法呼叫形式不變
 - [ ] cpbl-train／cpbl-train-pitching 於容器內以密封探針取證（docker compose run；嚴禁無探針真跑訓練），有隱患一併修
-- [ ] audit 工具重產前後盤點：未修入口 7→1（僅剩 🧊 cpbl-refresh-recent）
-- [ ] 回歸測試併入 tests/test_cli_help_guard.py；G4 凍結檔零 diff
+- [ ] audit 工具重產前後盤點：未修入口 7→1（僅剩 `cpbl-refresh-recent`，仍有副作用且另案處理）
+- [ ] 回歸測試併入 tests/test_cli_help_guard.py；#53 G4 Phase B 佔用檔零 diff
 
 ## 驗證
 

--- a/docs/tasks/DOC-G4-FREEZE-STALE1.md
+++ b/docs/tasks/DOC-G4-FREEZE-STALE1.md
@@ -1,9 +1,9 @@
-# DOC-G4-FREEZE-STALE1 修正兩處仍宣稱 G4 觀測凍結中的過期陳述　〔T1〕
+# DOC-G4-FREEZE-STALE1 修正 G4 觀測凍結過期陳述與可重跑掃描　〔T2〕
 
 - 需求：ruan6047　規劃：Claude Fable 5@Claude Code (PM)
 - 執行：待指派　查核：待指派
 - Initiative：—　spec 基線：DATA-INCOMPLETE-BOX-INGEST1-R1-02 @ merge_sha a1b54d8d927bae36e2c915b463277f734726b495
-- DB：db_scope=none
+- DB：db_scope=none　資源：`scripts/data_tz_boundary1.py`、`src/cpbl/completion.py`、`tests/test_tz_boundary.py`、`tests/test_cli_help_guard.py`、`docs/tasks/DEV-CLI-HELP-GUARD2.md`、`docs/tasks/DATA-TZ-BOUNDARY1.md`、`docs/research/DOC-G4-FREEZE-STALE1/`
 - 服務的原始目標：文件不得與權威來源矛盾，否則下一個執行者會依過期陳述誤判自己不能動碼
 - owner、worktree、iteration、交付／部署狀態、最後交接、資源宣告與 Log
   current-state 見對應 GitHub Issue／Project item（卡ID：DOC-G4-FREEZE-STALE1），不重複於此檔。
@@ -18,8 +18,11 @@
 - [ ] 不得只刪掉「凍結中」三個字了事：AI_WORKFLOW.md:26 剩下的「cpbl-refresh-recent 連 --help 都會觸發每日鏈」仍然為真且該修法現已解除阻塞，須明確寫出當前狀態（限制仍在／阻塞已解除）而非留下語意殘缺的句子
 - [ ] DATA-TZ-BOUNDARY1.md:19「鏈端只記錄不改」已被 #113 實際推翻（run_refresh_recent.py 已改），須反映此事實並說明該卡的鏈端範圍現在如何處理
 - [ ] 全庫掃一次同類過期陳述：grep 「G4」「凍結」「收窗後」等詞，把命中結果逐條判定為仍有效／已過期，artifact 由指令輸出產生而非人工列舉
+- [ ] `data_tz_boundary1.py` 不再把 ingest 全域標成 `chain_frozen`，artifact 改以「待 #53 G4 Phase B」表達鏈端延後原因
+- [ ] 修正 completion 與 CLI／時區測試的過期理由層敘述；保留「UTC 上界保守」與「CLI 仍有副作用」的既有結論
+- [ ] 全庫掃描 artifact 與可重跑指令落在 `docs/research/DOC-G4-FREEZE-STALE1/`，每個命中都帶判定與理由
 
 ## 驗證
 
 - [ ] grep -rn 「凍結」 docs/ 的前後對照，逐條標註處置
-- [ ] uv run ruff check（本卡不動碼，預期無影響）；不需 pytest 但須說明理由
+- [ ] uv run ruff check＋uv run pytest；不執行任何 crawler CLI 或 DB 寫入

--- a/scripts/data_tz_boundary1.py
+++ b/scripts/data_tz_boundary1.py
@@ -35,8 +35,8 @@ OUT_DIR = "docs/research/DATA-TZ-BOUNDARY1"
 # 本卡授權可改的寫入集（與 DEV-CLI-HELP-GUARD1 互斥）
 IN_SCOPE_PREFIXES = (
     "src/cpbl/api/", "src/cpbl/models/", "src/cpbl/features/", "src/cpbl/completion.py")
-# G4 觀測凍結＋平行卡佔用：只記錄不改
-CHAIN_FROZEN_PREFIX = "src/cpbl/ingest/"
+# 鏈端時區切換須待 #53 G4 Phase B 後另卡授權；不是已解除的 Gate 3 觀測凍結。
+CHAIN_DEFERRED_PREFIX = "src/cpbl/ingest/"
 
 # **自指檔案**：本卡的掃描器與其測試自身就含 CURRENT_DATE 字樣（偵測樣式／SQL 形態
 # 斷言），走 git ls-files 必然掃到自己。它們**不是 runtime SQL**，但也不能偷偷排除
@@ -139,8 +139,8 @@ def _classify(line: str) -> str:
 def _zone(path: str) -> str:
     if path in SELF_REFERENCE_FILES:
         return "tooling_self_reference"
-    if path.startswith(CHAIN_FROZEN_PREFIX):
-        return "chain_frozen"
+    if path.startswith(CHAIN_DEFERRED_PREFIX):
+        return "chain_deferred_pending_phase_b"
     if path.startswith(IN_SCOPE_PREFIXES):
         return "in_scope"
     if path.startswith("migrations/"):
@@ -231,11 +231,12 @@ def cmd_inventory(args: argparse.Namespace) -> dict:
         "sensitive_total": len(sensitive),
         "sensitive_in_scope": sorted(
             f"{h['file']}:{h['line']}" for h in sensitive if h["zone"] == "in_scope"),
-        "sensitive_chain_frozen_record_only": sorted(
-            f"{h['file']}:{h['line']}" for h in sensitive if h["zone"] == "chain_frozen"),
+        "sensitive_chain_deferred_pending_phase_b": sorted(
+            f"{h['file']}:{h['line']}" for h in sensitive
+            if h["zone"] == "chain_deferred_pending_phase_b"),
         "sensitive_outside_write_set": sorted(
             f"{h['file']}:{h['line']}" for h in sensitive
-            if h["zone"] not in ("in_scope", "chain_frozen")),
+            if h["zone"] not in ("in_scope", "chain_deferred_pending_phase_b")),
         "needs_human_review": [h for h in executable
                                if h["category"] == "unclassified"],
         "hits": hits,

--- a/src/cpbl/completion.py
+++ b/src/cpbl/completion.py
@@ -4,8 +4,8 @@
 
 * :func:`completed_games_sql` / :func:`is_completed`——**舊判準**（比分自證）。
   每日 refresh 鏈（``run_refresh_recent``、``cpbl_pitch_tracking``、``cpbl_gamelog``
-  的目標場清單）**本階段仍用它**：G4 觀測期進行中，換判準會改變爬取母體而污染觀測。
-  Phase 2（G4 Phase B 之後）再切換。
+  的目標場清單）**本階段仍用它**：#53 的 G4 Phase B 尚未完成，且其資源宣告佔用鏈端
+  writer；換判準會改變爬取母體。Phase 2（G4 Phase B 之後）再切換。
 * :func:`completed_games_sql_with_evidence` / :func:`is_completed_game`——**新判準**
   （比分 **OR** 外部證據），供非鏈消費端（API／features／models）。
 
@@ -26,8 +26,9 @@ DB 跑 UTC，故台北 00:00–08:00 這 8 小時兩者相差一天。這**不�
 
 * 兩者都是 ``game_date <= as_of`` 的**上界**用法。UTC 落後只會「晚 8 小時納入」，
   方向保守，DATA-TZ-BOUNDARY1 盤點後明確擱置、排在 REMEDY1 Phase 2 隨判準一起切。
-* 舊判準的呼叫端全在每日 refresh 鏈（``run_refresh_recent``）上，該鏈為 G4 觀測凍結檔；
-  改日界＝改爬取母體。且鏈的排程是 10:10 CST，落在窗外，**排程情境下不觸發此落差**。
+* 舊判準的呼叫端全在每日 refresh 鏈（``run_refresh_recent``）上，現由 #53 的 G4 Phase B
+  資源宣告佔用；改日界＝改爬取母體。且鏈的排程是 10:10 CST，落在窗外，**排程情境下不觸發
+  此落差**。
 
 實測落差面（2026-08-08 00:45 CST 窗內，唯讀全庫）：同一判準換 as_of，母體差**恰 1 場**
 ——``2026/D/119``（保留賽，原訂 06-16、續賽日 08-08，帶中止比分 5:4）。這不是巧合而是
@@ -78,8 +79,8 @@ def completed_games_sql(as_of_sql: str = UTC_TODAY_SQL) -> str:
     """回傳與 :func:`is_completed` 等價、可嵌入 ``cpbl.games`` 查詢的 SQL 條件（**舊判準**）。
 
     ⚠️ 預設值刻意仍是 UTC 的 ``CURRENT_DATE``（DATA-TZ-BOUNDARY1 盤點後**明確不改**）：
-    本函式現存的呼叫端都在每日 refresh 鏈上，G4 觀測期內換日界會改變爬取母體而污染
-    觀測。此處是 ``upper_bound`` 用法，UTC 落後只會「晚 8 小時納入」，方向保守、
+    本函式現存的呼叫端都在每日 refresh 鏈上；#53 的 G4 Phase B 尚未完成，換日界會改變
+    爬取母體。此處是 ``upper_bound`` 用法，UTC 落後只會「晚 8 小時納入」，方向保守、
     不會誤納未來場，因此擱置無資料正確性風險。與判準本身一起在 REMEDY1 Phase 2
     （G4 Phase B 後）切換。新程式碼請用 :data:`TAIPEI_TODAY_SQL`。
     """

--- a/tests/test_cli_help_guard.py
+++ b/tests/test_cli_help_guard.py
@@ -16,8 +16,8 @@
    `scripts/refresh-cpbl-prod.sh`）與各模組 docstring 裡的既有指令形式，逐一驗證解析結果
    與改版前語意相同。這層是本卡「不得為了加護欄而弄壞排程」的紅線。
 
-排除：`run_refresh_recent` 與 `cpbl_pitch_tracking` 由 INGEST-GAME-TM-REFACTOR1-G4
-觀測凍結，本卡明文不改，故不納入斷言範圍（它們的現況記錄在
+排除：`run_refresh_recent` 與 `cpbl_pitch_tracking` 由 #53 的 INGEST-GAME-TM-REFACTOR1-G4
+Phase B 資源佔用，本卡明文不改，故不納入斷言範圍（它們的現況記錄在
 `docs/research/DEV-CLI-HELP-GUARD1/cli-help-audit.md`）。
 """
 
@@ -33,7 +33,7 @@ import pytest
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
 
-# G4 觀測凍結：本卡只盤點不修改。
+# #53 的 G4 Phase B 資源佔用：本卡只盤點，不把 CLI 護欄改動併入逐球 writer。
 FROZEN_MODULES = {
     "cpbl.ingest.run_refresh_recent",
     "cpbl.ingest.cpbl_pitch_tracking",
@@ -153,7 +153,7 @@ def test_entry_discovery_actually_found_the_clis() -> None:
             "cpbl-build-features", "cpbl-build-sabr", "cpbl-classify-pitches",
             "cpbl-train-outcome", "cpbl-train-outcome-simple", "cpbl-train-pa-sim",
             "cpbl-train", "cpbl-train-pitching"} <= ids
-    assert "cpbl-refresh-recent" not in ids  # G4 凍結，明文排除
+    assert "cpbl-refresh-recent" not in ids  # 仍有 CLI 副作用，且其 writer 由 #53 佔用
 
 
 def test_only_declared_modules_are_unimportable_in_this_environment() -> None:

--- a/tests/test_tz_boundary.py
+++ b/tests/test_tz_boundary.py
@@ -162,7 +162,7 @@ def test_in_progress_years_lower_bound_uses_taipei_day() -> None:
 
 
 def test_legacy_chain_helper_deliberately_keeps_utc_default() -> None:
-    """舊 helper 的預設值刻意留 UTC——呼叫端在 G4 凍結的 refresh 鏈上。
+    """舊 helper 的預設值刻意留 UTC——鏈端切換待 #53 G4 Phase B 後另卡授權。
 
     這是**明確決定**而非遺漏：它是上界用法（保守），Phase 2 才隨判準一起切。
     """


### PR DESCRIPTION
## 摘要

移除會重新產生「G4 觀測凍結」過期敘述的時區掃描分類，並將鏈端延後原因改為 #53 G4 Phase B 的資源與實作依賴。

## 變更

- 將 `chain_frozen` 改為 `chain_deferred_pending_phase_b`。
- 同步更新 completion、測試與 CLI 文件的理由層。
- 新增可重跑的 G4 掃描 artifact；42 筆命中均有 disposition。
- `tests/test_box_revisions_deep_layer.py:113` 保留為唯一範圍外 PM follow-up。

## 驗證

- `uv run ruff check`
- `uv run pytest -q`：1550 passed、9 skipped
- `uv run python docs/research/DOC-G4-FREEZE-STALE1/scan_g4_freeze.py --verify`

## 審查

Claude Opus@Claude Code 已完成跨家族審查：APPROVE。
Source SHA：`4b5b8bd8bc92e8bb38b1c072ef39f4c427cbaf6d`
