### PR TITLE
docs(runbook): merge procedure that was actually executed (OPS-CPBL-MERGE-GATE1)

### DIFF
--- a/docs/AI_RUNBOOK.md
+++ b/docs/AI_RUNBOOK.md
@@ -491,6 +491,48 @@ EDITORIAL_TEST_DATABASE_URL=postgresql://cpbl:cpbl@localhost:5433/cpbl_data_edit
 
 **術語**：kind_code、island、幽靈島、GO/FO、保留賽等跨檔語意見 [`reference/GLOSSARY.md`](reference/GLOSSARY.md)，勿依單檔註解腦補。
 
+### 7.2.1 合併到 main（required check 已生效，2026-08-22）
+
+main 有 ruleset `main must be green`（id `21194141`），required context 是 **`api` 與 `web` 兩個**。
+`bypass_actors` 為空、`current_user_can_bypass` 為 never——**沒有人可以繞過，包含需求方**。
+
+**⛔ 沒有那兩個綠 check 的 commit 推不上 main。** 三個方向皆實測（2026-08-22）：
+
+| 情形 | 遠端回應 |
+|---|---|
+| 該 commit 上沒有 check | `- 2 of 2 required status checks are expected.` → 拒絕 |
+| 有 check 但紅 | `- Required status check "api" is failing.` → 拒絕 |
+| 兩個都綠 | 推得上去 |
+
+**⚠️ 分支頭的 check 名字不是 required 的名字。** `ci.yml` 的 name 表達式讓分支 push 產出的是
+`api (branch head)` / `web (branch head)`；不帶後綴的 `api` / `web` **只由 `pull_request` 事件與
+main push 產生**。⇒ **不開 PR 就永遠拿不到 required 的名字。**
+
+#### 合併程序（需求方 2026-08-22 裁定採此案）
+
+```bash
+git push origin <branch>                    # 1. 產生 api (branch head) / web (branch head)
+gh pr create --base main --head <branch>    # 2. pull_request run 把 api / web 掛上「分支頭 SHA」
+                                            #    （實測：merge ref 的 check-runs 是空的）
+# 3. 等兩個都綠
+gh api repos/ruan6047/cpbl-analytics/commits/<branch head sha>/check-runs \
+  --jq '.check_runs[] | select(.name=="api" or .name=="web") | "\(.name)=\(.conclusion)"'
+git merge --ff-only <branch> && git push origin main   # 4. 直推（分支頭已帶兩個綠 check）
+gh pr close <N>                                        # 5. 關掉那張 PR
+```
+
+**⚠️ 為什麼不用 GitHub 的 merge 按鈕**：那條路可行（ruleset 評估的是 PR head 而非 merge 結果），
+但它產生的 merge commit **trailer 完全沒有守衛**——`tests/test_commit_trailers.py` 的 `_base_ref`
+優先取本地 `main`，故 main push 的 CI run 上 `rev-list main..HEAD` 為空、**什麼都不檢**。
+⇒ merge 按鈕把「trailer 完整」押在人的記性上；ff-only 直推則不新增 commit，分支上那些
+commit 的 trailer 在分支頭的 CI run 上受檢。
+
+**⛔ 本機 `--no-ff` merge 後直推已不可行**（本 repo 2026-08-10～08-17 做過 14 次）：那個 merge commit
+是新 SHA、沒有任何 check，實測被拒。
+
+**⚠️ PR 被自動標記為 merged 不代表有人按了 merge 按鈕**：直推使 head 成為 base 的祖先時，
+GitHub 會自動標記。判斷是否經 PR 合併要看 `gh api repos/.../commits/<sha>/pulls` 與 commit 的雙親數。
+
 ### 7.3 部署 = push-to-deploy（在主站操作）
 1. 本 repo：commit + push（CI 只跑 lint + tsc，**不部署**）。
 2. 主站 `~/Dev/PersonalWebsite`：`apps/subprojects/cpbl-analytics` checkout 到新 commit → `git add` 該 submodule → commit（**只動 submodule 一行**，勿夾帶主站其他未提交變更，VPS 是 `git reset --hard origin/main`）→ push。

--- a/docs/AI_RUNBOOK.md
+++ b/docs/AI_RUNBOOK.md
@@ -516,30 +516,67 @@ main push 產生**。⇒ **不開 PR 就永遠拿不到 required 的名字。**
 
 #### 合併程序（需求方 2026-08-22 裁定採此案）
 
+⚠️ **本程序全程不 `checkout main`**，因為本專案是多 worktree 實況、主 checkout 已佔用
+`main`——在 feature worktree 執行 `git checkout main` 逐字得
+`fatal: 'main' is already used by worktree at '/Users/ruanruan/Dev/cpbl-analytics'`。
+⛔ **早期版本寫的 `checkout main` + `merge --ff-only` 在本 repo 從來就跑不起來**，那是憑
+記憶寫的、不是實跑序列。下面每一步都已逐一實測，證據見本節末。
+
 ```bash
+REPO=ruan6047/cpbl-analytics
+BRANCH="<branch>"   # ⚠️ 佔位符必須留引號，否則 < 會被當成重導向
+PR="<N>"
+
 # 1. 分支 push → 產生 api (branch head) / web (branch head)
-git push origin <branch>
+git push origin "$BRANCH"
 
 # 2. 開 PR → pull_request run 把 api / web 掛上「分支頭 SHA」
 #    （實測：merge ref 的 check-runs 是空的，所以掛的是分支頭不是 merge ref）
-gh pr create --base main --head <branch>
+gh pr create --base main --head "$BRANCH"
 
-# 3. 等兩個 required 都綠（⚠️ 看的是不帶後綴的那兩個）
-gh api repos/ruan6047/cpbl-analytics/commits/$(git rev-parse <branch>)/check-runs \
-  --jq '.check_runs[] | select(.name=="api" or .name=="web") | "\(.name)=\(.conclusion)"'
+# 3. ⭐ 機械驗證兩個 required 都綠——⛔ 不是印出來讓人讀
+SHA=$(git rev-parse "$BRANCH")
+GREEN=$(gh api "repos/$REPO/commits/$SHA/check-runs" --jq '
+  [.check_runs[] | select(.name=="api" or .name=="web")] as $r
+  | (($r | map(.name) | unique) == ["api","web"])
+    and ($r | map(.conclusion == "success") | all)')
+if [ "$GREEN" != "true" ]; then echo "⛔ required check 未全綠，停"; exit 1; fi
 
-# 4. ⚠️ 切到「已同步的 main」再快進——⛔ 少了這兩行，第 5 行會是 no-op、
-#    push 只會推本地既有 main，而分支根本沒被合併
-git checkout main
-git fetch origin && git merge --ff-only origin/main
-git merge --ff-only <branch>
-git push origin main
+# 4. ⭐ refspec push——不需 checkout main，多 worktree 下照樣成立。
+#    非 fast-forward 時 git 自己會拒絕（`! [rejected] ... (non-fast-forward)`）
+git push origin "$BRANCH:main"
 
-# 5. ⚠️ 通常不需要：直推使 head 成為 base 的祖先後，GitHub 會自動把 PR 標成 merged
-#    （PR 168 即為實例）。⛔ 只有在確認第 4 步真的推上去、而 PR 仍為 open 時才關它。
-gh pr view <N> --json state --jq '.state'   # 先看，MERGED 就別動
-gh pr close <N>                             # 僅在仍為 OPEN 時
+# 5. ⭐ 真正的 shell 條件：先證 main 確實含分支 HEAD，才談關 PR
+git fetch -q origin
+if git merge-base --is-ancestor "$SHA" origin/main; then
+  STATE=$(gh pr view "$PR" --repo "$REPO" --json state --jq '.state')
+  if [ "$STATE" = "OPEN" ]; then gh pr close "$PR" --repo "$REPO"
+  else echo "PR 已是 $STATE（直推使 head 成為 base 的祖先後 GitHub 會自動標 merged），不動"; fi
+else
+  echo "⛔ main 未包含 $SHA — 合併沒成功，⛔ 絕對不要關 PR"
+fi
 ```
+
+⚠️ **第 3 步為什麼不能寫 `length == 2`**：一個 commit 若同時經過分支 push 與 main push，
+`api`／`web` **各會出現兩次**——實測 `113f029a` 上 `total_count = 6`（`api` ×2、`web` ×2、
+`api (branch head)`、`web (branch head)`）。`length == 2` 會**否決一個完全綠的 commit**。
+判準必須是「兩個名字都在 **且** 全部 success」，⛔ 不是「剛好兩筆」。
+
+**逐步實測證據**（2026-08-22，皆以 `git rev-parse` 取得的真實 SHA）：
+
+| 測項 | 輸入 | 實得 |
+|---|---|---|
+| 第 3 步判準 vs 全綠 | `113f029a12928097e3d56a85e172daf9c830ed89` | `true` |
+| 第 3 步判準 vs 紅 | `451a86de5bea425a438de4214a40157bb61662e5` | `false` |
+| 第 3 步判準 vs 無 check | `1c3bc2ecf9ed2ac8837bec2226eb455a3ab06ce2`（`total_count=0`） | `false` |
+| 第 4 步 refspec push（feature worktree，main 被主 checkout 佔用） | `git push --dry-run origin HEAD:main` | `113f029a..31e97938  HEAD -> main` |
+| 第 5 步條件 vs 未合併 SHA | `31e97938…` | 判「未合併」⇒ 不關 PR |
+| 第 5 步條件 vs 已合併 SHA | `113f029a…` | 判「已合併」⇒ 才允許關 PR |
+
+⚠️ **未驗到**：第 4 步的 `--dry-run` **不證明 ruleset 會放行**。ruleset 對 refspec push 的
+三個方向已於前次探針實測（無 check → 拒、紅 → 拒、綠 → 過），但那三次與本表的
+`--dry-run` 是**不同次執行**，⛔ 本表不宣稱它們是同一次取證。
+
 **⚠️ 為什麼不用 GitHub 的 merge 按鈕**：⛔ **那條路在本 repo 從未實測過**——判斷它可行的
 依據是姊妹 repo `ai-workflow` 於 2026-08-22 在同型 ruleset 下的三次 PR merge 全部成功，
 且其 merge commit 上只有 1 個 check（來自 merge 之後的 main push）⇒ 推得 ruleset 評估的是

--- a/docs/AI_RUNBOOK.md
+++ b/docs/AI_RUNBOOK.md
@@ -521,14 +521,24 @@ git merge --ff-only <branch> && git push origin main   # 4. 直推（分支頭�
 gh pr close <N>                                        # 5. 關掉那張 PR
 ```
 
-**⚠️ 為什麼不用 GitHub 的 merge 按鈕**：那條路可行（ruleset 評估的是 PR head 而非 merge 結果），
-但它產生的 merge commit **trailer 完全沒有守衛**——`tests/test_commit_trailers.py` 的 `_base_ref`
+**⚠️ 為什麼不用 GitHub 的 merge 按鈕**：⛔ **那條路在本 repo 從未實測過**——判斷它可行的
+依據是姊妹 repo `ai-workflow` 於 2026-08-22 在同型 ruleset 下的三次 PR merge 全部成功，
+且其 merge commit 上只有 1 個 check（來自 merge 之後的 main push）⇒ 推得 ruleset 評估的是
+PR head 而非 merge 結果。**那是推論，不是本 repo 的觀測。**
+
+不採用它的理由與可行性無關，而是：它產生的 merge commit **trailer 完全沒有守衛**——`tests/test_commit_trailers.py` 的 `_base_ref`
 優先取本地 `main`，故 main push 的 CI run 上 `rev-list main..HEAD` 為空、**什麼都不檢**。
 ⇒ merge 按鈕把「trailer 完整」押在人的記性上；ff-only 直推則不新增 commit，分支上那些
 commit 的 trailer 在分支頭的 CI run 上受檢。
 
 **⛔ 本機 `--no-ff` merge 後直推已不可行**（本 repo 2026-08-10～08-17 做過 14 次）：那個 merge commit
-是新 SHA、沒有任何 check，實測被拒。
+是新 SHA、沒有任何 check。實測（2026-08-22，雙親 merge commit）遠端逐字回：
+
+```
+remote: error: GH013: Repository rule violations found for refs/heads/main.
+remote: - 2 of 2 required status checks are expected.
+ ! [remote rejected]   HEAD -> main (push declined due to repository rule violations)
+```
 
 **⚠️ PR 被自動標記為 merged 不代表有人按了 merge 按鈕**：直推使 head 成為 base 的祖先時，
 GitHub 會自動標記。判斷是否經 PR 合併要看 `gh api repos/.../commits/<sha>/pulls` 與 commit 的雙親數。

--- a/docs/AI_RUNBOOK.md
+++ b/docs/AI_RUNBOOK.md
@@ -496,6 +496,12 @@ EDITORIAL_TEST_DATABASE_URL=postgresql://cpbl:cpbl@localhost:5433/cpbl_data_edit
 main 有 ruleset `main must be green`（id `21194141`），required context 是 **`api` 與 `web` 兩個**。
 `bypass_actors` 為空、`current_user_can_bypass` 為 never——**沒有人可以繞過，包含需求方**。
 
+⚠️ 該 ruleset 另帶 `strict_required_status_checks_policy: true`（要求分支與 base 同步），
+但**在下面這條 ff-only 程序上它構造上碰不到**：分支若落後，`git push` 會先被 git 自己以
+`non-fast-forward` 擋下（實測 2026-08-22，`remote:` 的規則訊息完全沒出現）；分支若不落後，
+strict 的條件本來就成立。⇒ **它只在走 PR merge 時才有作用，而本程序不走那條。**
+⛔ 不要把它讀成「本流程多了一道保護」。
+
 **⛔ 沒有那兩個綠 check 的 commit 推不上 main。** 三個方向皆實測（2026-08-22）：
 
 | 情形 | 遠端回應 |

--- a/docs/AI_RUNBOOK.md
+++ b/docs/AI_RUNBOOK.md
@@ -507,7 +507,7 @@ strict 的條件本來就成立。⇒ **它只在走 PR merge 時才有作用，
 | 情形 | 遠端回應 |
 |---|---|
 | 該 commit 上沒有 check | `- 2 of 2 required status checks are expected.` → 拒絕 |
-| 有 check 但紅 | `- Required status check "api" is failing.` → 拒絕 |
+| 有 check 但紅 | `- Required status check "api" is failing.` → 拒絕（SHA `451a86de5bea425a438de4214a40157bb61662e5`，[run 32569531859](https://github.com/ruan6047/cpbl-analytics/actions/runs/32569531859)；該 SHA 的 check-runs 至今仍是 `api = failure`） |
 | 兩個都綠 | 推得上去 |
 
 **⚠️ 分支頭的 check 名字不是 required 的名字。** `ci.yml` 的 name 表達式讓分支 push 產出的是
@@ -517,25 +517,42 @@ main push 產生**。⇒ **不開 PR 就永遠拿不到 required 的名字。**
 #### 合併程序（需求方 2026-08-22 裁定採此案）
 
 ```bash
-git push origin <branch>                    # 1. 產生 api (branch head) / web (branch head)
-gh pr create --base main --head <branch>    # 2. pull_request run 把 api / web 掛上「分支頭 SHA」
-                                            #    （實測：merge ref 的 check-runs 是空的）
-# 3. 等兩個都綠
-gh api repos/ruan6047/cpbl-analytics/commits/<branch head sha>/check-runs \
-  --jq '.check_runs[] | select(.name=="api" or .name=="web") | "\(.name)=\(.conclusion)"'
-git merge --ff-only <branch> && git push origin main   # 4. 直推（分支頭已帶兩個綠 check）
-gh pr close <N>                                        # 5. 關掉那張 PR
-```
+# 1. 分支 push → 產生 api (branch head) / web (branch head)
+git push origin <branch>
 
+# 2. 開 PR → pull_request run 把 api / web 掛上「分支頭 SHA」
+#    （實測：merge ref 的 check-runs 是空的，所以掛的是分支頭不是 merge ref）
+gh pr create --base main --head <branch>
+
+# 3. 等兩個 required 都綠（⚠️ 看的是不帶後綴的那兩個）
+gh api repos/ruan6047/cpbl-analytics/commits/$(git rev-parse <branch>)/check-runs \
+  --jq '.check_runs[] | select(.name=="api" or .name=="web") | "\(.name)=\(.conclusion)"'
+
+# 4. ⚠️ 切到「已同步的 main」再快進——⛔ 少了這兩行，第 5 行會是 no-op、
+#    push 只會推本地既有 main，而分支根本沒被合併
+git checkout main
+git fetch origin && git merge --ff-only origin/main
+git merge --ff-only <branch>
+git push origin main
+
+# 5. ⚠️ 通常不需要：直推使 head 成為 base 的祖先後，GitHub 會自動把 PR 標成 merged
+#    （PR 168 即為實例）。⛔ 只有在確認第 4 步真的推上去、而 PR 仍為 open 時才關它。
+gh pr view <N> --json state --jq '.state'   # 先看，MERGED 就別動
+gh pr close <N>                             # 僅在仍為 OPEN 時
+```
 **⚠️ 為什麼不用 GitHub 的 merge 按鈕**：⛔ **那條路在本 repo 從未實測過**——判斷它可行的
 依據是姊妹 repo `ai-workflow` 於 2026-08-22 在同型 ruleset 下的三次 PR merge 全部成功，
 且其 merge commit 上只有 1 個 check（來自 merge 之後的 main push）⇒ 推得 ruleset 評估的是
 PR head 而非 merge 結果。**那是推論，不是本 repo 的觀測。**
 
-不採用它的理由與可行性無關，而是：它產生的 merge commit **trailer 完全沒有守衛**——`tests/test_commit_trailers.py` 的 `_base_ref`
-優先取本地 `main`，故 main push 的 CI run 上 `rev-list main..HEAD` 為空、**什麼都不檢**。
-⇒ merge 按鈕把「trailer 完整」押在人的記性上；ff-only 直推則不新增 commit，分支上那些
-commit 的 trailer 在分支頭的 CI run 上受檢。
+**不採用它是需求方 2026-08-22 的政策選擇，⛔ 不是因為它被證明比較差。** 已證的只有一件事：
+`tests/test_commit_trailers.py` 的 `_base_ref` 優先取本地 `main`，故 main push 的 CI run 上
+`rev-list main..HEAD` 為空、什麼都不檢 ⇒ **GitHub 產生的那個 merge commit 不受該守衛檢查**。
+
+⚠️ **那不等於「走 merge 按鈕比較不安全」**——PR 內人為寫的那些 commit 照樣受檢（`pull_request`
+run 只排除 synthetic merge）。⛔ 未被證明的是「merge commit 自身缺 trailer 會造成什麼後果」。
+政策選擇的理由是：ff-only 直推**不新增任何 commit**，所以不存在一筆沒人檢查的 commit；
+merge 按鈕則會新增一筆，其 trailer 完整性只能靠人。**這是偏好，不是安全性判決。**
 
 **⛔ 本機 `--no-ff` merge 後直推已不可行**（本 repo 2026-08-10～08-17 做過 14 次）：那個 merge commit
 是新 SHA、沒有任何 check。實測（2026-08-22，雙親 merge commit）遠端逐字回：

--- a/docs/AI_RUNBOOK.md
+++ b/docs/AI_RUNBOOK.md
@@ -525,7 +525,7 @@ main push 產生**。⇒ **不開 PR 就永遠拿不到 required 的名字。**
 ```bash
 REPO=ruan6047/cpbl-analytics
 BRANCH="<branch>"   # ⚠️ 佔位符必須留引號，否則 < 會被當成重導向
-PR="<N>"
+# ⛔ 這裡刻意沒有 PR=<N>：PR 編號由分支反查，見第 5 步
 
 # 1. 分支 push → 產生 api (branch head) / web (branch head)
 git push origin "$BRANCH"
@@ -546,21 +546,43 @@ if [ "$GREEN" != "true" ]; then echo "⛔ required check 未全綠，停"; exit 
 #    非 fast-forward 時 git 自己會拒絕（`! [rejected] ... (non-fast-forward)`）
 git push origin "$BRANCH:main"
 
-# 5. ⭐ 真正的 shell 條件：先證 main 確實含分支 HEAD，才談關 PR
+# 5. ⭐ 兩層綁定後才關 PR。⛔ 不接受人工填入的 PR 編號——填錯的那張若剛好也是
+#    OPEN，第一層條件仍成立，就會關掉一張無關的 PR。編號一律由分支反查。
 git fetch -q origin
-if git merge-base --is-ancestor "$SHA" origin/main; then
-  STATE=$(gh pr view "$PR" --repo "$REPO" --json state --jq '.state')
-  if [ "$STATE" = "OPEN" ]; then gh pr close "$PR" --repo "$REPO"
-  else echo "PR 已是 $STATE（直推使 head 成為 base 的祖先後 GitHub 會自動標 merged），不動"; fi
-else
-  echo "⛔ main 未包含 $SHA — 合併沒成功，⛔ 絕對不要關 PR"
+if ! git merge-base --is-ancestor "$SHA" origin/main; then
+  echo "⛔ main 未包含 $SHA — 合併沒成功，⛔ 絕對不要關 PR"; exit 1
 fi
+PRJ=$(gh pr list --repo "$REPO" --head "$BRANCH" --state open \
+        --json number,headRefName,headRefOid)
+case "$(echo "$PRJ" | jq 'length')" in
+  0) echo "本分支無 open PR（直推使 head 成為 base 祖先後 GitHub 會自動標 merged），不動"
+     exit 0 ;;
+  1) : ;;
+  *) echo "⛔ 本分支有多張 open PR，人工判斷，停"; exit 1 ;;
+esac
+BIND=$(echo "$PRJ" | jq -r --arg b "$BRANCH" --arg s "$SHA" \
+         '.[0] | (.headRefName == $b and .headRefOid == $s)')
+if [ "$BIND" != "true" ]; then
+  echo "⛔ 該 PR 的 head 與 $BRANCH@$SHA 不符，停"; exit 1
+fi
+gh pr close "$(echo "$PRJ" | jq -r '.[0].number')" --repo "$REPO"
 ```
+
+⚠️ **第 3 步的保守方向是刻意的**：判準要求**同名的每一筆** check-run 都 success。
+若 API 同時保留舊的 failure 與 re-run 後的 success，判準會回 `false`——**即使 GitHub
+自己可能已依最新一筆放行**。⛔ 這不修：判準寧可多擋一次讓人回頭看，也不要因為選錯
+「哪一筆才算數」而放行一次不該過的合併。要通過就把失敗那筆 re-run 到綠、或推一個新
+commit。⚠️ 本 repo 的歷史裡**沒有**同名 check 一紅一綠並存的實例，⇒ 該情境是依
+API 語意推的，**未實測**。
 
 ⚠️ **第 3 步為什麼不能寫 `length == 2`**：一個 commit 若同時經過分支 push 與 main push，
 `api`／`web` **各會出現兩次**——實測 `113f029a` 上 `total_count = 6`（`api` ×2、`web` ×2、
 `api (branch head)`、`web (branch head)`）。`length == 2` 會**否決一個完全綠的 commit**。
 判準必須是「兩個名字都在 **且** 全部 success」，⛔ 不是「剛好兩筆」。
+
+⚠️ **第 5 步為什麼不留 `PR=<N>` 這個輸入**：留著它、再加一道「比對 headRefName」的檢查，
+擋得住的只是「檢查有跑」；填錯的那張若剛好也是 OPEN，第一層 `--is-ancestor` 條件**照樣成立**。
+⇒ 把編號改成由 `--head "$BRANCH"` 反查，**填錯這件事在構造上就不存在了**。
 
 **逐步實測證據**（2026-08-22，皆以 `git rev-parse` 取得的真實 SHA）：
 
@@ -572,6 +594,9 @@ fi
 | 第 4 步 refspec push（feature worktree，main 被主 checkout 佔用） | `git push --dry-run origin HEAD:main` | `113f029a..31e97938  HEAD -> main` |
 | 第 5 步條件 vs 未合併 SHA | `31e97938…` | 判「未合併」⇒ 不關 PR |
 | 第 5 步條件 vs 已合併 SHA | `113f029a…` | 判「已合併」⇒ 才允許關 PR |
+| 第 5 步綁定 vs 分支對＋SHA 對 | `ai/opus-5/OPS-CPBL-MERGE-GATE1` @ `8bd77018…` | `BIND=true` ⇒ 才會關 PR #170 |
+| 第 5 步綁定 vs 分支對＋SHA 錯 | 同分支 @ 舊交付 `31e97938…` | `BIND=false` ⇒ ⛔ 停，不關 |
+| 第 5 步綁定 vs 分支無 open PR | `ai/opus-5/DOC-ROADMAP-OPEN-DEFAULT-STALE1` | `length=0` ⇒ `exit 0`，不關 |
 
 ⚠️ **未驗到**：第 4 步的 `--dry-run` **不證明 ruleset 會放行**。ruleset 對 refspec push 的
 三個方向已於前次探針實測（無 check → 拒、紅 → 拒、綠 → 過），但那三次與本表的


### PR DESCRIPTION
卡：#166 `OPS-CPBL-MERGE-GATE1`

本 PR 存在的用途之一是讓查核者能跑到程序的第 3 步——required 名字 `api`／`web` 只在 open PR 的 `pull_request` run 產生，沒有 open PR 時第 3 步必然回 false。

R2 兩個阻擋皆已處置，根因同一個：程序憑記憶寫、沒實跑。本輪先跑再寫，六個測項全用真實 SHA 實測。

🤖 Generated with [Claude Code](https://claude.com/claude-code)