### PR TITLE
docs(runbook): fix three merge-procedure defects that only an end-to-end run exposed

### DIFF
--- a/docs/AI_RUNBOOK.md
+++ b/docs/AI_RUNBOOK.md
@@ -523,6 +523,8 @@ main push 產生**。⇒ **不開 PR 就永遠拿不到 required 的名字。**
 記憶寫的、不是實跑序列。下面每一步都已逐一實測，證據見本節末。
 
 ```bash
+set -euo pipefail   # ⛔ 少了它，第 1、2 步失敗後仍會往下跑，第 3 步就對「過期 SHA」判綠
+
 REPO=ruan6047/cpbl-analytics
 BRANCH="<branch>"   # ⚠️ 佔位符必須留引號，否則 < 會被當成重導向
 # ⛔ 這裡刻意沒有 PR=<N>：PR 編號由分支反查，見第 5 步
@@ -532,7 +534,9 @@ git push origin "$BRANCH"
 
 # 2. 開 PR → pull_request run 把 api / web 掛上「分支頭 SHA」
 #    （實測：merge ref 的 check-runs 是空的，所以掛的是分支頭不是 merge ref）
-gh pr create --base main --head "$BRANCH"
+#    ⚠️ --fill 不可省：非互動下逐字得
+#    `must provide --title and --body (or --fill ...) when not running interactively`
+gh pr create --base main --head "$BRANCH" --fill
 
 # 3. ⭐ 機械驗證兩個 required 都綠——⛔ 不是印出來讓人讀
 SHA=$(git rev-parse "$BRANCH")
@@ -543,8 +547,23 @@ GREEN=$(gh api "repos/$REPO/commits/$SHA/check-runs" --jq '
 if [ "$GREEN" != "true" ]; then echo "⛔ required check 未全綠，停"; exit 1; fi
 
 # 4. ⭐ refspec push——不需 checkout main，多 worktree 下照樣成立。
-#    非 fast-forward 時 git 自己會拒絕（`! [rejected] ... (non-fast-forward)`）
+#    非 fast-forward 時 git 自己會拒絕（`! [rejected] ... (non-fast-forward)`）；
+#    ⚠️ 被拒代表 main 已前進，先 `git rebase origin/main` 再從第 1 步重跑（SHA 會變）
 git push origin "$BRANCH:main"
+
+# 4b. ⭐ 把本地 main 追上——⛔ 少了這步，wfcli 的收尾守衛會擋掉 release。
+#     refspec push 本質上「不」更新本地 main ref（那正是它不需 checkout 的代價），
+#     而 merge_verified_local 比對的就是本地 main，會判 diverged 並以 rc=5 拒絕。
+#     兩條路互補、實測皆 rc=0：main 沒被 checkout 時直接更新 ref；被佔用時 git 會
+#     逐字拒絕（`refusing to fetch into branch 'refs/heads/main' checked out at …`），
+#     此時到「持有 main 的那個 worktree」快進。⛔ 不要假設它是主 checkout——那是
+#     未經驗證的前提，若該處在別的分支，merge 會把 origin/main 併進錯的分支。
+if ! git fetch -q origin main:main 2>/dev/null; then
+  MAINWT=$(git worktree list --porcelain \
+           | awk '/^worktree /{w=$2} /^branch refs\/heads\/main$/{print w; exit}')
+  [ -n "$MAINWT" ] || { echo "⛔ 找不到持有 main 的 worktree，人工處理"; exit 1; }
+  git -C "$MAINWT" merge --ff-only origin/main
+fi
 
 # 5. ⭐ 兩層綁定後才關 PR。⛔ 不接受人工填入的 PR 編號——填錯的那張若剛好也是
 #    OPEN，第一層條件仍成立，就會關掉一張無關的 PR。編號一律由分支反查。

--- a/docs/AI_RUNBOOK.md
+++ b/docs/AI_RUNBOOK.md
@@ -559,10 +559,17 @@ git push origin "$BRANCH:main"
 #     此時到「持有 main 的那個 worktree」快進。⛔ 不要假設它是主 checkout——那是
 #     未經驗證的前提，若該處在別的分支，merge 會把 origin/main 併進錯的分支。
 if ! git fetch -q origin main:main 2>/dev/null; then
-  # ⛔ 不可用 $2：porcelain 對含空白的路徑原樣輸出，$2 只會取到第一段
-  #    （實測 '…/main worktree' 被截成 '…/main'，git -C 隨即 rc=128）
-  MAINWT=$(git worktree list --porcelain \
-           | awk '/^worktree /{w=substr($0,10)} /^branch refs\/heads\/main$/{print w; exit}')
+  # ⛔ 這裡不能用逐行解析。porcelain 對路徑是原樣輸出：含空白時 awk $2 只取第一段，
+  #    含換行時整筆紀錄會被拆成兩行、任何以行為單位的取法都拿不到完整路徑。
+  #    實測含換行的 holder 路徑：逐行版取到 '…/holder/main'、git -C 隨即 rc=128。
+  #    ⇒ 用 --porcelain -z（每筆屬性以 NUL 結尾）＋ read -r -d '' 逐筆讀。
+  MAINWT=""; w=""
+  while IFS= read -r -d '' rec; do
+    case "$rec" in
+      "worktree "*)            w=${rec#worktree } ;;
+      "branch refs/heads/main") MAINWT=$w; break ;;
+    esac
+  done < <(git worktree list --porcelain -z)
   [ -n "$MAINWT" ] || { echo "⛔ 找不到持有 main 的 worktree，人工處理"; exit 1; }
   git -C "$MAINWT" merge --ff-only origin/main
 fi

--- a/docs/AI_RUNBOOK.md
+++ b/docs/AI_RUNBOOK.md
@@ -559,8 +559,10 @@ git push origin "$BRANCH:main"
 #     此時到「持有 main 的那個 worktree」快進。⛔ 不要假設它是主 checkout——那是
 #     未經驗證的前提，若該處在別的分支，merge 會把 origin/main 併進錯的分支。
 if ! git fetch -q origin main:main 2>/dev/null; then
+  # ⛔ 不可用 $2：porcelain 對含空白的路徑原樣輸出，$2 只會取到第一段
+  #    （實測 '…/main worktree' 被截成 '…/main'，git -C 隨即 rc=128）
   MAINWT=$(git worktree list --porcelain \
-           | awk '/^worktree /{w=$2} /^branch refs\/heads\/main$/{print w; exit}')
+           | awk '/^worktree /{w=substr($0,10)} /^branch refs\/heads\/main$/{print w; exit}')
   [ -n "$MAINWT" ] || { echo "⛔ 找不到持有 main 的 worktree，人工處理"; exit 1; }
   git -C "$MAINWT" merge --ff-only origin/main
 fi


### PR DESCRIPTION
#166 合併時唯一未驗項是「程序未端到端跑過一次真實合併」。以它實際合併 #166 與 #169
時，三個缺陷同時現形——三者靜態閱讀都看不出來。

一、第 2 步 gh pr create 缺 --title/--body/--fill，非互動下逐字得
    must provide --title and --body ... when not running interactively。已加 --fill。

二、整段無 set -e。第 2 步失敗後腳本仍往下跑；若失敗的是第 1 步，第 3 步會對過期
    SHA 判綠。已加 set -euo pipefail。

三、refspec push 本質上不更新本地 main ref（那正是它不需 checkout 的代價），
    合併後本地 main 落後，而 wfcli 收尾守衛 merge_verified_local 比對的正是本地
    main ⇒ #169 的 release 首次呼叫實得 rc=5、證明=diverged 被擋。已加第 4b 步。

⭐ 4b 的第一版是憑推理寫的，實測抓到它自己的缺陷：它假設「主 checkout 一定在 main」，
    若該處在別的分支會把 origin/main 併進錯的分支。改為閉合形式——先試直接更新 ref
    （main 沒被 checkout 時可行），git 拒絕時再從 git worktree list --porcelain 找出
    持有 main 的那個 worktree 快進。兩個情境實測皆 rc=0。

Requested-by: ruan6047
Planned-by: Claude Opus 5@Claude Code (PM)
Implemented-by: Claude Opus 5@Claude Code
Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
