### PR TITLE
docs(roadmap): regenerate the schedule block so closed cards leave it

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -788,13 +788,12 @@ git -C ~/Dev/ai-workflow show ae8f741:cli/src/wf_cli/commands/handoff_cmd.py | s
 
 <!-- roadmap-lines:begin -->
 
-<!-- cpbl-roadmap-lines/v11；活卡 37；每線 {'L1': 8, 'L2': 7, 'L3': 6, 'L4': 11, 'L5': 5} -->
+<!-- cpbl-roadmap-lines/v11；活卡 35；每線 {'L1': 7, 'L2': 7, 'L3': 6, 'L4': 11, 'L5': 4} -->
 
-### L1 資料正確性（8 張）
+### L1 資料正確性（7 張）
 
 | 卡 | # | tier | 狀態 | 下一個必要 Gate／阻塞條件 | 去留 |
 |---|---|---|---|---|---|
-| `DATA-BOX-REVISION-SNAPSHOT1` | #109 | T2 | ⏸阻塞 | 解除阻塞條件（阻塞對象與解阻後的處置見該卡 Issue 的 handoff 事由） | |
 | `DATA-RE24-PROD-REBUILD1` | #119 | T4 | ⏸阻塞 | 解除阻塞條件（阻塞對象與解阻後的處置見該卡 Issue 的 handoff 事由） | |
 | `DEV-VERIFY-TM-ASSERTS1` | #50 | T2 | 💡需求 | 規劃 Gate：Discovery → Design → Plan，需求方核可後才進 Backlog | |
 | `INGEST-GAME-TM-REFACTOR1-G4` | #53 | T4 | ⏸阻塞 | 解除阻塞條件（阻塞對象與解阻後的處置見該卡 Issue 的 handoff 事由） | |
@@ -842,15 +841,14 @@ git -C ~/Dev/ai-workflow show ae8f741:cli/src/wf_cli/commands/handoff_cmd.py | s
 | `ML-WP-ROLLWIN1` | #95 | T4 | 💡需求 | 規劃 Gate：Discovery → Design → Plan，需求方核可後才進 Backlog | |
 | `RESEARCH-REASON-RESTATE1` | #105 | T2 | 💡需求 | 規劃 Gate：Discovery → Design → Plan，需求方核可後才進 Backlog | |
 
-### L5 開發／文件基礎（5 張）
+### L5 開發／文件基礎（4 張）
 
 | 卡 | # | tier | 狀態 | 下一個必要 Gate／阻塞條件 | 去留 |
 |---|---|---|---|---|---|
 | `DEV-CI-LOCALE-UNDECLARED1` | #129 | T1 | 💡需求 | 規劃 Gate：Discovery → Design → Plan，需求方核可後才進 Backlog | |
-| `DEV-ROADMAP-LINES-SILENT-ZERO1` | #143 | T2 | 💡需求 | 規劃 Gate：Discovery → Design → Plan，需求方核可後才進 Backlog | |
 | `DEV-WP-DISCLOSURE-SOURCE1` | #147 | T3 | 📥Backlog | 認領（線 WIP 須有空位） | |
 | `DOC-LIVELOG-SEMANTICS-GAP1` | #108 | T1 | 💡需求 | 規劃 Gate：Discovery → Design → Plan，需求方核可後才進 Backlog | |
-| `DOC-ROADMAP-STALE-SYNC1` | #162 | T2 | 🔨執行中 | 交付並 handoff 送審 | |
+| `DOC-ROADMAP-LINES-REGEN1` | #174 | T1 | 🔨執行中 | 交付並 handoff 送審 | |
 
 <!-- roadmap-lines:end -->
 


### PR DESCRIPTION
關閉 https://github.com/ruan6047/cpbl-analytics/issues/174

`docs/ROADMAP.md` §3 的排程區塊列著三張已經結案的卡（`DATA-BOX-REVISION-SNAPSHOT1` #109、`DEV-ROADMAP-LINES-SILENT-ZERO1` #143、`DOC-ROADMAP-STALE-SYNC1` #162，看板上皆 🏁完成），讀它的人會以為那三張還在排程。

- 區塊由 `scripts/roadmap_lines.py` 的產生器重生後貼回，⛔ **不是手刪那三行** —— 手刪今天也能讓 `--check` 變綠，但下次有卡結案又會壞，且會讓後人以為區塊有人在維護。
- 活卡 37 → 35，各線分佈 `{L1:8, L2:7, L3:6, L4:11, L5:5}` → `{L1:7, L2:7, L3:6, L4:11, L5:4}`。
- ⛔ 零行為改動：`scripts/roadmap_lines.py` 一行未動，⛔ 未建「誰負責重生」的機械執行者（那是 `DEV-ROADMAP-LINES-SILENT-ZERO1` 已登記的缺口）。

查核（跨 session 獨立查核者）以**單變數對照實驗**證明區塊是產生器產出而非手刪：只把看板 JSON 中 `#174` 自己的交付狀態改回產生當時值（`assert n==1` 保證只動一格），其餘 209 items 原封不動，重跑 render 後與交付區塊 `diff` 為空、`sha256` 皆 `98377cfa71464ced2a46acdc2a5b35ccd5c2ef1a4688c7127ce33229f62fb0f4`。回歸：基線 `2063 passed, 114 skipped`、交付 `2064 passed, 113 skipped`，收集數兩邊同為 2177。

⚠️ 已知且刻意不處理：本卡把自己寫進了區塊，⇒ 它結案後會離開活卡集合而區塊不會被重生，`--check` 將回「只在 ROADMAP：`[DOC-ROADMAP-LINES-REGEN1]`」——與本卡痛點同形狀的新一筆（查核 finding R1-02，major、非阻塞）。淨帳仍是改善：3 筆陳舊 → 結案後 1 筆。建機械執行者屬另一張卡。

Reviewed-by: Claude Opus 5@Claude Code (Reviewer)
Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
